### PR TITLE
Fix a few issues

### DIFF
--- a/convex/queries.ts
+++ b/convex/queries.ts
@@ -16,6 +16,6 @@ export const lastN = query({
       .query("messages")
       .order("desc")
       .take(args.count);
-    return lastMessages.toReversed();
+    return lastMessages.reverse();
   },
 });


### PR DESCRIPTION
This fixes a couple different issues I ran into while adding tests for one of my apps:
* `api.foo.bar.default` wasn't supported (because the path is `api.foo.bar` and splitting on `:` doesn't quite work)
* `db.patch(doc._id, { _id: doc._id, _creationTime: doc._creationTime, somethingElse: "foo" })` would error (which is inconsistent with how it works in prod)
* I added support for `db.normalizeId` using our fake ID format

Also as a drive-by change, I used `reverse` instead of `toReversed` because the latter is only available in Node 20 (which I personally haven't installed yet) just so `npm run test` comes up green.