### PR TITLE
fix serializable

### DIFF
--- a/convex/mutations.test.ts
+++ b/convex/mutations.test.ts
@@ -112,6 +112,7 @@ test("concurrent append", async () => {
   }
   await Promise.all(concurrentCalls);
   const messages = await t.query(api.mutations.list);
+  // Regression test: if the mutations are not properly serialized, the final
+  // message becomes "hello!!".
   expect(messages).toMatchObject([{ body: "hello!!!!!!!!!!", author: "lee" }]);
 });
-

--- a/convex/mutations.test.ts
+++ b/convex/mutations.test.ts
@@ -99,3 +99,19 @@ test("replace after insert", async () => {
   });
   expect(messages).toMatchObject([{ body: "hi", author: "michal" }]);
 });
+
+test("concurrent append", async () => {
+  const t = convexTest(schema);
+  const id = await t.mutation(api.mutations.insert, {
+    body: "hello",
+    author: "lee",
+  });
+  const concurrentCalls = [];
+  for (let i = 0; i < 10; i++) {
+    concurrentCalls.push(t.mutation(api.mutations.append, { id, suffix: "!" }));
+  }
+  await Promise.all(concurrentCalls);
+  const messages = await t.query(api.mutations.list);
+  expect(messages).toMatchObject([{ body: "hello!!!!!!!!!!", author: "lee" }]);
+});
+

--- a/convex/mutations.test.ts
+++ b/convex/mutations.test.ts
@@ -112,7 +112,7 @@ test("concurrent append", async () => {
   }
   await Promise.all(concurrentCalls);
   const messages = await t.query(api.mutations.list);
-  // Regression test: if the mutations are not properly serialized, the final
+  // Regression test: if the mutations are not serializable, the final
   // message becomes "hello!!".
   expect(messages).toMatchObject([{ body: "hello!!!!!!!!!!", author: "lee" }]);
 });

--- a/convex/mutations.ts
+++ b/convex/mutations.ts
@@ -57,3 +57,11 @@ export const throws = mutation({
     throw new Error("I changed my mind");
   },
 });
+
+export const append = mutation({
+  args: { id: v.id("messages"), suffix: v.string() },
+  handler: async (ctx, { id, suffix }) => {
+    const message = (await ctx.db.get(id))!;
+    await ctx.db.patch(id, { body: message.body + suffix });
+  }
+});

--- a/index.ts
+++ b/index.ts
@@ -151,7 +151,7 @@ class DatabaseFake {
   }
 
   async startTransaction() {
-    if (this._waitOnCurrentFunction !== null) {
+    while (this._waitOnCurrentFunction !== null) {
       await this._waitOnCurrentFunction;
     }
     let markTransactionDone: () => void;

--- a/index.ts
+++ b/index.ts
@@ -145,7 +145,7 @@ class DatabaseFake {
               Object.entries(schema.tables).map(([name, tableSchema]) => [
                 name,
                 (tableSchema as any).export(),
-              ]),
+              ])
             ),
           };
   }
@@ -186,7 +186,7 @@ class DatabaseFake {
       throw new Error(
         `Invalid argument \`id\` for \`db.get\`, expected string but got '${typeof id}': ${
           id as any
-        }`,
+        }`
       );
     }
 
@@ -201,7 +201,7 @@ class DatabaseFake {
   // Note that this is not the format the real backend
   // uses for IDs.
   private _generateId<TableName extends string>(
-    table: TableName,
+    table: TableName
   ): GenericId<TableName> {
     const id = this._nextDocId.toString() + ";" + table;
     this._nextDocId += 1;
@@ -242,7 +242,7 @@ class DatabaseFake {
     if (value._id !== undefined && value._id !== _id) {
       throw new Error(
         `Provided \`_id\` field value "${value._id}" ` +
-          `does not match the document ID "${_id}"`,
+          `does not match the document ID "${_id}"`
       );
     }
     if (
@@ -251,7 +251,7 @@ class DatabaseFake {
     ) {
       throw new Error(
         `Provided \`_creationTime\` field value ${value._creationTime} ` +
-          `does not match the document's creation time ${_creationTime}`,
+          `does not match the document's creation time ${_creationTime}`
       );
     }
     delete value["_id"];
@@ -272,7 +272,7 @@ class DatabaseFake {
     if (value._id !== undefined && value._id !== document._id) {
       throw new Error(
         `Provided \`_id\` field value "${value._id}" ` +
-          `does not match the document ID "${document._id}"`,
+          `does not match the document ID "${document._id}"`
       );
     }
     if (
@@ -281,7 +281,7 @@ class DatabaseFake {
     ) {
       throw new Error(
         `Provided \`_creationTime\` field value ${value._creationTime} ` +
-          `does not match the document's creation time ${document._creationTime}`,
+          `does not match the document's creation time ${document._creationTime}`
       );
     }
     delete value["_id"];
@@ -391,7 +391,7 @@ class DatabaseFake {
 
   private _iterateDocs(
     tableName: string,
-    callback: (doc: GenericDocument) => void,
+    callback: (doc: GenericDocument) => void
   ) {
     for (const write of Object.values(this._writes)) {
       if (write.isInsert) {
@@ -449,12 +449,12 @@ class DatabaseFake {
         const indexes = this._schema?.tables.get(tableName)?.indexes;
         const index = indexes?.find(
           ({ indexDescriptor }: { indexDescriptor: string }) =>
-            indexDescriptor === indexName,
+            indexDescriptor === indexName
         );
         if (index === undefined) {
           throw new Error(
             `Cannot use index "${indexName}" for table "${tableName}" because ` +
-              `it is not declared in the schema.`,
+              `it is not declared in the schema.`
           );
         }
         fieldPathsToSortBy = index.fields;
@@ -475,13 +475,13 @@ class DatabaseFake {
     }
     const filters = query.operators
       .filter(
-        (operator): operator is { filter: FilterJson } => "filter" in operator,
+        (operator): operator is { filter: FilterJson } => "filter" in operator
       )
       .map((operator) => operator.filter);
 
     const limit =
       query.operators.filter(
-        (operator): operator is { limit: number } => "limit" in operator,
+        (operator): operator is { limit: number } => "limit" in operator
       )[0] ?? null;
 
     results = results.filter((v) => filters.every((f) => evaluateFilter(v, f)));
@@ -513,7 +513,7 @@ class DatabaseFake {
     tableAndIndexName: string,
     vector: number[],
     expressions: SerializedRangeExpression[],
-    limit: number,
+    limit: number
   ) {
     const results: GenericDocument[] = [];
     const [tableName, indexName] = tableAndIndexName.split(".");
@@ -525,12 +525,12 @@ class DatabaseFake {
     const vectorIndexes = this._schema?.tables.get(tableName)?.vectorIndexes;
     const vectorIndex = vectorIndexes?.find(
       ({ indexDescriptor }: { indexDescriptor: string }) =>
-        indexDescriptor === indexName,
+        indexDescriptor === indexName
     );
     if (vectorIndex === undefined) {
       throw new Error(
         `Cannot use vector index "${indexName}" for table "${tableName}" because ` +
-          `it is not declared in the schema.`,
+          `it is not declared in the schema.`
       );
     }
     const { vectorField } = vectorIndex;
@@ -639,7 +639,7 @@ function evaluateFieldPath(fieldPath: string, document: any) {
 
 function evaluateFilter(
   document: GenericDocument,
-  filter: any,
+  filter: any
 ): Value | undefined {
   if (filter.$eq !== undefined) {
     return (
@@ -727,7 +727,7 @@ function evaluateFilter(
 
 function evaluateRangeFilter(
   document: GenericDocument,
-  expr: SerializedRangeExpression,
+  expr: SerializedRangeExpression
 ) {
   const result = evaluateFieldPath(expr.fieldPath, document);
   const value = evaluateValue(expr.value);
@@ -754,7 +754,7 @@ function evaluateValue(value: JSONValue) {
 
 function evaluateSearchFilter(
   document: GenericDocument,
-  filter: SerializedSearchFilter,
+  filter: SerializedSearchFilter
 ) {
   const result = evaluateFieldPath(filter.fieldPath, document);
   switch (filter.type) {
@@ -817,7 +817,7 @@ function validateValidator(validator: ValidatorJSON, value: any) {
     case "number": {
       if (typeof value !== "number") {
         throw new Error(
-          `Validator error: Expected \`number\`, got \`${value}\``,
+          `Validator error: Expected \`number\`, got \`${value}\``
         );
       }
       return;
@@ -825,7 +825,7 @@ function validateValidator(validator: ValidatorJSON, value: any) {
     case "bigint": {
       if (typeof value !== "bigint") {
         throw new Error(
-          `Validator error: Expected \`bigint\`, got \`${value}\``,
+          `Validator error: Expected \`bigint\`, got \`${value}\``
         );
       }
       return;
@@ -833,7 +833,7 @@ function validateValidator(validator: ValidatorJSON, value: any) {
     case "boolean": {
       if (typeof value !== "boolean") {
         throw new Error(
-          `Validator error: Expected \`boolean\`, got \`${value}\``,
+          `Validator error: Expected \`boolean\`, got \`${value}\``
         );
       }
       return;
@@ -841,7 +841,7 @@ function validateValidator(validator: ValidatorJSON, value: any) {
     case "string": {
       if (typeof value !== "string") {
         throw new Error(
-          `Validator error: Expected \`string\`, got \`${value}\``,
+          `Validator error: Expected \`string\`, got \`${value}\``
         );
       }
       return;
@@ -849,7 +849,7 @@ function validateValidator(validator: ValidatorJSON, value: any) {
     case "bytes": {
       if (!(value instanceof ArrayBuffer)) {
         throw new Error(
-          `Validator error: Expected \`ArrayBuffer\`, got \`${value}\``,
+          `Validator error: Expected \`ArrayBuffer\`, got \`${value}\``
         );
       }
       return;
@@ -862,7 +862,7 @@ function validateValidator(validator: ValidatorJSON, value: any) {
         throw new Error(
           `Validator error: Expected \`${
             validator.value as any
-          }\`, got \`${value}\``,
+          }\`, got \`${value}\``
         );
       }
       return;
@@ -870,12 +870,12 @@ function validateValidator(validator: ValidatorJSON, value: any) {
     case "id": {
       if (typeof value !== "string") {
         throw new Error(
-          `Validator error: Expected \`string\`, got \`${value}\``,
+          `Validator error: Expected \`string\`, got \`${value}\``
         );
       }
       if (tableNameFromId(value) !== validator.tableName) {
         throw new Error(
-          `Validator error: Expected ID for table "${validator.tableName}", got \`${value}\``,
+          `Validator error: Expected ID for table "${validator.tableName}", got \`${value}\``
         );
       }
       return;
@@ -883,7 +883,7 @@ function validateValidator(validator: ValidatorJSON, value: any) {
     case "array": {
       if (!Array.isArray(value)) {
         throw new Error(
-          `Validator error: Expected \`Array\`, got \`${value}\``,
+          `Validator error: Expected \`Array\`, got \`${value}\``
         );
       }
       for (const v of value) {
@@ -894,21 +894,21 @@ function validateValidator(validator: ValidatorJSON, value: any) {
     case "object": {
       if (typeof value !== "object") {
         throw new Error(
-          `Validator error: Expected \`object\`, got \`${value}\``,
+          `Validator error: Expected \`object\`, got \`${value}\``
         );
       }
       if (!isSimpleObject(value)) {
         throw new Error(
-          `Validator error: Expected a plain old JavaScript \`object\`, got \`${value}\``,
+          `Validator error: Expected a plain old JavaScript \`object\`, got \`${value}\``
         );
       }
       for (const [k, { fieldType, optional }] of Object.entries(
-        validator.value,
+        validator.value
       )) {
         if (value[k] === undefined) {
           if (!optional) {
             throw new Error(
-              `Validator error: Missing required field \`${k}\` in object`,
+              `Validator error: Missing required field \`${k}\` in object`
             );
           }
         } else {
@@ -918,7 +918,7 @@ function validateValidator(validator: ValidatorJSON, value: any) {
       for (const k of Object.keys(value)) {
         if (validator.value[k] === undefined) {
           throw new Error(
-            `Validator error: Unexpected field \`${k}\` in object`,
+            `Validator error: Unexpected field \`${k}\` in object`
           );
         }
       }
@@ -1005,27 +1005,24 @@ function asyncSyscallImpl(db: DatabaseFake) {
         const { name, args: queryArgs } = args;
         return JSON.stringify(
           convexToJson(
-            await withAuth().query(makeFunctionReference(name), queryArgs),
-          ),
+            await withAuth().query(makeFunctionReference(name), queryArgs)
+          )
         );
       }
       case "1.0/actions/mutation": {
         const { name, args: mutationArgs } = args;
         return JSON.stringify(
           convexToJson(
-            await withAuth().mutation(
-              makeFunctionReference(name),
-              mutationArgs,
-            ),
-          ),
+            await withAuth().mutation(makeFunctionReference(name), mutationArgs)
+          )
         );
       }
       case "1.0/actions/action": {
         const { name, args: actionArgs } = args;
         return JSON.stringify(
           convexToJson(
-            await withAuth().action(makeFunctionReference(name), actionArgs),
-          ),
+            await withAuth().action(makeFunctionReference(name), actionArgs)
+          )
         );
       }
       case "1.0/actions/schedule": {
@@ -1050,7 +1047,7 @@ function asyncSyscallImpl(db: DatabaseFake) {
               }
               if (job.state.kind !== "pending") {
                 throw new Error(
-                  `\`convexTest\` invariant error: Unexpected scheduled function state when starting it: ${job.state.kind}`,
+                  `\`convexTest\` invariant error: Unexpected scheduled function state when starting it: ${job.state.kind}`
                 );
               }
             }
@@ -1060,7 +1057,7 @@ function asyncSyscallImpl(db: DatabaseFake) {
             } catch (error) {
               console.error(
                 `Error when running scheduled function ${name}`,
-                error,
+                error
               );
               db.patch(jobId, {
                 state: { kind: "failed" },
@@ -1072,14 +1069,14 @@ function asyncSyscallImpl(db: DatabaseFake) {
               const job = db.get(jobId) as ScheduledFunction;
               if (job.state.kind !== "inProgress") {
                 throw new Error(
-                  `\`convexTest\` invariant error: Unexpected scheduled function state after it finished running: ${job.state.kind}`,
+                  `\`convexTest\` invariant error: Unexpected scheduled function state after it finished running: ${job.state.kind}`
                 );
               }
             }
             db.patch(jobId, { state: { kind: "success" } });
             db.jobFinished(jobId);
           }) as () => void,
-          tsInSecs * 1000 - Date.now(),
+          tsInSecs * 1000 - Date.now()
         );
         return JSON.stringify(convexToJson(jobId));
       }
@@ -1099,7 +1096,7 @@ function asyncSyscallImpl(db: DatabaseFake) {
           // Probably an unintentional implementation in Convex
           // where expressions is only a single expression
           expressions === null ? [] : [expressions],
-          limit,
+          limit
         );
         return JSON.stringify(convexToJson({ results }));
       }
@@ -1137,7 +1134,7 @@ function asyncSyscallImpl(db: DatabaseFake) {
       }
       default: {
         throw new Error(
-          `\`convexTest\` does not support async syscall: "${op}"`,
+          `\`convexTest\` does not support async syscall: "${op}"`
         );
       }
     }
@@ -1191,7 +1188,7 @@ async function blobSha(blob: Blob) {
 async function waitForInProgressScheduledFunctions(): Promise<boolean> {
   const inProgressJobs = (await withAuth().run(async (ctx) => {
     return (await ctx.db.system.query("_scheduled_functions").collect()).filter(
-      (job: ScheduledFunction) => job.state.kind === "inProgress",
+      (job: ScheduledFunction) => job.state.kind === "inProgress"
     );
   })) as ScheduledFunction[];
   let numRemaining = inProgressJobs.length;
@@ -1264,8 +1261,8 @@ export type TestConvexForDataModel<DataModel extends GenericDataModel> = {
    */
   run: <Output>(
     func: (
-      ctx: GenericMutationCtx<DataModel> & { storage: StorageActionWriter },
-    ) => Promise<Output>,
+      ctx: GenericMutationCtx<DataModel> & { storage: StorageActionWriter }
+    ) => Promise<Output>
   ) => Promise<Output>;
 
   /**
@@ -1304,7 +1301,7 @@ export type TestConvexForDataModel<DataModel extends GenericDataModel> = {
 };
 
 export type TestConvexForDataModelAndIdentity<
-  DataModel extends GenericDataModel,
+  DataModel extends GenericDataModel
 > = {
   /**
    * To test functions which depend on the current authenticated user identity
@@ -1315,7 +1312,7 @@ export type TestConvexForDataModelAndIdentity<
    *   generated automatically.
    */
   withIdentity(
-    identity: Partial<UserIdentity>,
+    identity: Partial<UserIdentity>
   ): TestConvexForDataModel<DataModel>;
 } & TestConvexForDataModel<DataModel>;
 
@@ -1338,13 +1335,13 @@ function moduleCache(specifiedModules?: Record<string, () => Promise<any>>) {
   const modules = specifiedModules ?? import.meta.glob("./convex/**/*.*s");
   const prefix = findModulesRoot(
     Object.keys(modules),
-    specifiedModules !== undefined,
+    specifiedModules !== undefined
   );
   const modulesWithoutExtension = Object.fromEntries(
     Object.entries(modules).map(([path, module]) => [
       path.replace(/\.[^.]+$/, ""),
       module,
-    ]),
+    ])
   );
   return async (path: string) => {
     const module = modulesWithoutExtension[prefix + path];
@@ -1357,7 +1354,7 @@ function moduleCache(specifiedModules?: Record<string, () => Promise<any>>) {
 
 function findModulesRoot(modulesPaths: string[], userProvidedModules: boolean) {
   const generatedFilePath = modulesPaths.find((path) =>
-    path.includes("_generated"),
+    path.includes("_generated")
   );
   if (generatedFilePath !== undefined) {
     return generatedFilePath.split("_generated", 2)[0];
@@ -1371,7 +1368,7 @@ function findModulesRoot(modulesPaths: string[], userProvidedModules: boolean) {
           '"_generated" directory'
         : "If your Convex functions aren't defined in a directory " +
           'called "convex" sibling to your node_modules, ' +
-          "provide the second argument to `convexTest`"),
+          "provide the second argument to `convexTest`")
   );
 }
 
@@ -1389,7 +1386,7 @@ function findModulesRoot(modulesPaths: string[], userProvidedModules: boolean) {
 export const convexTest = <Schema extends GenericSchema>(
   schema?: SchemaDefinition<Schema, boolean>,
   // For example `import.meta.glob("./**/*.*s")`
-  modules?: Record<string, () => Promise<any>>,
+  modules?: Record<string, () => Promise<any>>
 ): TestConvex<SchemaDefinition<Schema, boolean>> => {
   const db = new DatabaseFake(schema ?? null);
   (global as unknown as { Convex: any }).Convex = {
@@ -1408,7 +1405,7 @@ export const convexTest = <Schema extends GenericSchema>(
       const tokenIdentifier =
         identity.tokenIdentifier ?? `${issuer}|${subject}`;
       return withAuth(
-        new AuthFake({ ...identity, subject, issuer, tokenIdentifier }),
+        new AuthFake({ ...identity, subject, issuer, tokenIdentifier })
       );
     },
     ...withAuth(),
@@ -1419,7 +1416,7 @@ function withAuth(auth: AuthFake = new AuthFake()) {
   const runTransaction = async <T>(
     handler: (ctx: any, args: any) => T,
     args: any,
-    extraCtx: any = {},
+    extraCtx: any = {}
   ): Promise<T> => {
     const m = mutationGeneric({
       handler: (ctx: any, a: any) => {
@@ -1464,7 +1461,7 @@ function withAuth(auth: AuthFake = new AuthFake()) {
     mutation: async (functionReference: any, args: any): Promise<Value> => {
       const func = await getFunctionFromReference(
         functionReference,
-        "mutation",
+        "mutation"
       );
       validateValidator(JSON.parse(func.exportArgs()), args ?? {});
       return await runTransaction(func, args);
@@ -1494,7 +1491,7 @@ function withAuth(auth: AuthFake = new AuthFake()) {
         }
       ).invokeAction(
         requestId,
-        JSON.stringify(convexToJson([parseArgs(args)])),
+        JSON.stringify(convexToJson([parseArgs(args)]))
       );
       return jsonToConvex(JSON.parse(rawResult));
     },
@@ -1572,7 +1569,7 @@ function withAuth(auth: AuthFake = new AuthFake()) {
     },
 
     finishAllScheduledFunctions: async (
-      advanceTimers: () => void,
+      advanceTimers: () => void
     ): Promise<void> => {
       let hadScheduledFunctions;
       do {
@@ -1584,7 +1581,7 @@ function withAuth(auth: AuthFake = new AuthFake()) {
 }
 
 function parseArgs(
-  args: Record<string, Value> | undefined,
+  args: Record<string, Value> | undefined
 ): Record<string, Value> {
   if (args === undefined) {
     return {};
@@ -1593,7 +1590,7 @@ function parseArgs(
     throw new Error(
       `The arguments to a Convex function must be an object. Received: ${
         args as any
-      }`,
+      }`
     );
   }
   return args;
@@ -1601,14 +1598,14 @@ function parseArgs(
 
 async function getFunctionFromReference(
   functionReference: FunctionReference<any, any, any, any>,
-  type: "query" | "mutation" | "action" | "any",
+  type: "query" | "mutation" | "action" | "any"
 ) {
   return await getFunctionFromName(getFunctionName(functionReference), type);
 }
 
 async function getFunctionFromName(
   functionName: string,
-  type: "query" | "mutation" | "action" | "any",
+  type: "query" | "mutation" | "action" | "any"
 ) {
   // api.foo.bar.default -> `foo/bar`
   const [modulePath, maybeExportName] = functionName.split(":");
@@ -1620,33 +1617,33 @@ async function getFunctionFromName(
   const func = module[exportName];
   if (func === undefined) {
     throw new Error(
-      `Expected a Convex function exported from module "${modulePath}" as \`${exportName}\`, but there is no such export.`,
+      `Expected a Convex function exported from module "${modulePath}" as \`${exportName}\`, but there is no such export.`
     );
   }
   if (typeof func !== "function") {
     throw new Error(
-      `Expected a Convex function exported from module "${modulePath}" as \`${exportName}\`, but got: ${func}`,
+      `Expected a Convex function exported from module "${modulePath}" as \`${exportName}\`, but got: ${func}`
     );
   }
   switch (type) {
     case "query":
       if (!func.isQuery) {
         throw new Error(
-          `Expected a query function, but the function exported from module "${modulePath}" as \`${exportName}\` is not a query.`,
+          `Expected a query function, but the function exported from module "${modulePath}" as \`${exportName}\` is not a query.`
         );
       }
       break;
     case "mutation":
       if (!func.isMutation) {
         throw new Error(
-          `Expected a mutation function, but the function exported from module "${modulePath}" as \`${exportName}\` is not a mutation.`,
+          `Expected a mutation function, but the function exported from module "${modulePath}" as \`${exportName}\` is not a mutation.`
         );
       }
       break;
     case "action":
       if (!func.isAction) {
         throw new Error(
-          `Expected an action function, but the function exported from module "${modulePath}" as \`${exportName}\` is not an action.`,
+          `Expected an action function, but the function exported from module "${modulePath}" as \`${exportName}\` is not an action.`
         );
       }
       break;

--- a/index.ts
+++ b/index.ts
@@ -145,12 +145,16 @@ class DatabaseFake {
               Object.entries(schema.tables).map(([name, tableSchema]) => [
                 name,
                 (tableSchema as any).export(),
-              ])
+              ]),
             ),
           };
   }
 
   async startTransaction() {
+    // Note the loop is important, as the current promise might resolve and a
+    // new transaction could start before we get woken up.
+    // This is the standard pattern for condition variables:
+    // https://en.wikipedia.org/wiki/Monitor_(synchronization)
     while (this._waitOnCurrentFunction !== null) {
       await this._waitOnCurrentFunction;
     }
@@ -182,7 +186,7 @@ class DatabaseFake {
       throw new Error(
         `Invalid argument \`id\` for \`db.get\`, expected string but got '${typeof id}': ${
           id as any
-        }`
+        }`,
       );
     }
 
@@ -197,7 +201,7 @@ class DatabaseFake {
   // Note that this is not the format the real backend
   // uses for IDs.
   private _generateId<TableName extends string>(
-    table: TableName
+    table: TableName,
   ): GenericId<TableName> {
     const id = this._nextDocId.toString() + ";" + table;
     this._nextDocId += 1;
@@ -238,7 +242,7 @@ class DatabaseFake {
     if (value._id !== undefined && value._id !== _id) {
       throw new Error(
         `Provided \`_id\` field value "${value._id}" ` +
-          `does not match the document ID "${_id}"`
+          `does not match the document ID "${_id}"`,
       );
     }
     if (
@@ -247,7 +251,7 @@ class DatabaseFake {
     ) {
       throw new Error(
         `Provided \`_creationTime\` field value ${value._creationTime} ` +
-          `does not match the document's creation time ${_creationTime}`
+          `does not match the document's creation time ${_creationTime}`,
       );
     }
     delete value["_id"];
@@ -268,7 +272,7 @@ class DatabaseFake {
     if (value._id !== undefined && value._id !== document._id) {
       throw new Error(
         `Provided \`_id\` field value "${value._id}" ` +
-          `does not match the document ID "${document._id}"`
+          `does not match the document ID "${document._id}"`,
       );
     }
     if (
@@ -277,7 +281,7 @@ class DatabaseFake {
     ) {
       throw new Error(
         `Provided \`_creationTime\` field value ${value._creationTime} ` +
-          `does not match the document's creation time ${document._creationTime}`
+          `does not match the document's creation time ${document._creationTime}`,
       );
     }
     delete value["_id"];
@@ -387,7 +391,7 @@ class DatabaseFake {
 
   private _iterateDocs(
     tableName: string,
-    callback: (doc: GenericDocument) => void
+    callback: (doc: GenericDocument) => void,
   ) {
     for (const write of Object.values(this._writes)) {
       if (write.isInsert) {
@@ -445,12 +449,12 @@ class DatabaseFake {
         const indexes = this._schema?.tables.get(tableName)?.indexes;
         const index = indexes?.find(
           ({ indexDescriptor }: { indexDescriptor: string }) =>
-            indexDescriptor === indexName
+            indexDescriptor === indexName,
         );
         if (index === undefined) {
           throw new Error(
             `Cannot use index "${indexName}" for table "${tableName}" because ` +
-              `it is not declared in the schema.`
+              `it is not declared in the schema.`,
           );
         }
         fieldPathsToSortBy = index.fields;
@@ -471,13 +475,13 @@ class DatabaseFake {
     }
     const filters = query.operators
       .filter(
-        (operator): operator is { filter: FilterJson } => "filter" in operator
+        (operator): operator is { filter: FilterJson } => "filter" in operator,
       )
       .map((operator) => operator.filter);
 
     const limit =
       query.operators.filter(
-        (operator): operator is { limit: number } => "limit" in operator
+        (operator): operator is { limit: number } => "limit" in operator,
       )[0] ?? null;
 
     results = results.filter((v) => filters.every((f) => evaluateFilter(v, f)));
@@ -509,7 +513,7 @@ class DatabaseFake {
     tableAndIndexName: string,
     vector: number[],
     expressions: SerializedRangeExpression[],
-    limit: number
+    limit: number,
   ) {
     const results: GenericDocument[] = [];
     const [tableName, indexName] = tableAndIndexName.split(".");
@@ -521,12 +525,12 @@ class DatabaseFake {
     const vectorIndexes = this._schema?.tables.get(tableName)?.vectorIndexes;
     const vectorIndex = vectorIndexes?.find(
       ({ indexDescriptor }: { indexDescriptor: string }) =>
-        indexDescriptor === indexName
+        indexDescriptor === indexName,
     );
     if (vectorIndex === undefined) {
       throw new Error(
         `Cannot use vector index "${indexName}" for table "${tableName}" because ` +
-          `it is not declared in the schema.`
+          `it is not declared in the schema.`,
       );
     }
     const { vectorField } = vectorIndex;
@@ -635,7 +639,7 @@ function evaluateFieldPath(fieldPath: string, document: any) {
 
 function evaluateFilter(
   document: GenericDocument,
-  filter: any
+  filter: any,
 ): Value | undefined {
   if (filter.$eq !== undefined) {
     return (
@@ -723,7 +727,7 @@ function evaluateFilter(
 
 function evaluateRangeFilter(
   document: GenericDocument,
-  expr: SerializedRangeExpression
+  expr: SerializedRangeExpression,
 ) {
   const result = evaluateFieldPath(expr.fieldPath, document);
   const value = evaluateValue(expr.value);
@@ -750,7 +754,7 @@ function evaluateValue(value: JSONValue) {
 
 function evaluateSearchFilter(
   document: GenericDocument,
-  filter: SerializedSearchFilter
+  filter: SerializedSearchFilter,
 ) {
   const result = evaluateFieldPath(filter.fieldPath, document);
   switch (filter.type) {
@@ -813,7 +817,7 @@ function validateValidator(validator: ValidatorJSON, value: any) {
     case "number": {
       if (typeof value !== "number") {
         throw new Error(
-          `Validator error: Expected \`number\`, got \`${value}\``
+          `Validator error: Expected \`number\`, got \`${value}\``,
         );
       }
       return;
@@ -821,7 +825,7 @@ function validateValidator(validator: ValidatorJSON, value: any) {
     case "bigint": {
       if (typeof value !== "bigint") {
         throw new Error(
-          `Validator error: Expected \`bigint\`, got \`${value}\``
+          `Validator error: Expected \`bigint\`, got \`${value}\``,
         );
       }
       return;
@@ -829,7 +833,7 @@ function validateValidator(validator: ValidatorJSON, value: any) {
     case "boolean": {
       if (typeof value !== "boolean") {
         throw new Error(
-          `Validator error: Expected \`boolean\`, got \`${value}\``
+          `Validator error: Expected \`boolean\`, got \`${value}\``,
         );
       }
       return;
@@ -837,7 +841,7 @@ function validateValidator(validator: ValidatorJSON, value: any) {
     case "string": {
       if (typeof value !== "string") {
         throw new Error(
-          `Validator error: Expected \`string\`, got \`${value}\``
+          `Validator error: Expected \`string\`, got \`${value}\``,
         );
       }
       return;
@@ -845,7 +849,7 @@ function validateValidator(validator: ValidatorJSON, value: any) {
     case "bytes": {
       if (!(value instanceof ArrayBuffer)) {
         throw new Error(
-          `Validator error: Expected \`ArrayBuffer\`, got \`${value}\``
+          `Validator error: Expected \`ArrayBuffer\`, got \`${value}\``,
         );
       }
       return;
@@ -858,7 +862,7 @@ function validateValidator(validator: ValidatorJSON, value: any) {
         throw new Error(
           `Validator error: Expected \`${
             validator.value as any
-          }\`, got \`${value}\``
+          }\`, got \`${value}\``,
         );
       }
       return;
@@ -866,12 +870,12 @@ function validateValidator(validator: ValidatorJSON, value: any) {
     case "id": {
       if (typeof value !== "string") {
         throw new Error(
-          `Validator error: Expected \`string\`, got \`${value}\``
+          `Validator error: Expected \`string\`, got \`${value}\``,
         );
       }
       if (tableNameFromId(value) !== validator.tableName) {
         throw new Error(
-          `Validator error: Expected ID for table "${validator.tableName}", got \`${value}\``
+          `Validator error: Expected ID for table "${validator.tableName}", got \`${value}\``,
         );
       }
       return;
@@ -879,7 +883,7 @@ function validateValidator(validator: ValidatorJSON, value: any) {
     case "array": {
       if (!Array.isArray(value)) {
         throw new Error(
-          `Validator error: Expected \`Array\`, got \`${value}\``
+          `Validator error: Expected \`Array\`, got \`${value}\``,
         );
       }
       for (const v of value) {
@@ -890,21 +894,21 @@ function validateValidator(validator: ValidatorJSON, value: any) {
     case "object": {
       if (typeof value !== "object") {
         throw new Error(
-          `Validator error: Expected \`object\`, got \`${value}\``
+          `Validator error: Expected \`object\`, got \`${value}\``,
         );
       }
       if (!isSimpleObject(value)) {
         throw new Error(
-          `Validator error: Expected a plain old JavaScript \`object\`, got \`${value}\``
+          `Validator error: Expected a plain old JavaScript \`object\`, got \`${value}\``,
         );
       }
       for (const [k, { fieldType, optional }] of Object.entries(
-        validator.value
+        validator.value,
       )) {
         if (value[k] === undefined) {
           if (!optional) {
             throw new Error(
-              `Validator error: Missing required field \`${k}\` in object`
+              `Validator error: Missing required field \`${k}\` in object`,
             );
           }
         } else {
@@ -914,7 +918,7 @@ function validateValidator(validator: ValidatorJSON, value: any) {
       for (const k of Object.keys(value)) {
         if (validator.value[k] === undefined) {
           throw new Error(
-            `Validator error: Unexpected field \`${k}\` in object`
+            `Validator error: Unexpected field \`${k}\` in object`,
           );
         }
       }
@@ -1001,24 +1005,27 @@ function asyncSyscallImpl(db: DatabaseFake) {
         const { name, args: queryArgs } = args;
         return JSON.stringify(
           convexToJson(
-            await withAuth().query(makeFunctionReference(name), queryArgs)
-          )
+            await withAuth().query(makeFunctionReference(name), queryArgs),
+          ),
         );
       }
       case "1.0/actions/mutation": {
         const { name, args: mutationArgs } = args;
         return JSON.stringify(
           convexToJson(
-            await withAuth().mutation(makeFunctionReference(name), mutationArgs)
-          )
+            await withAuth().mutation(
+              makeFunctionReference(name),
+              mutationArgs,
+            ),
+          ),
         );
       }
       case "1.0/actions/action": {
         const { name, args: actionArgs } = args;
         return JSON.stringify(
           convexToJson(
-            await withAuth().action(makeFunctionReference(name), actionArgs)
-          )
+            await withAuth().action(makeFunctionReference(name), actionArgs),
+          ),
         );
       }
       case "1.0/actions/schedule": {
@@ -1043,7 +1050,7 @@ function asyncSyscallImpl(db: DatabaseFake) {
               }
               if (job.state.kind !== "pending") {
                 throw new Error(
-                  `\`convexTest\` invariant error: Unexpected scheduled function state when starting it: ${job.state.kind}`
+                  `\`convexTest\` invariant error: Unexpected scheduled function state when starting it: ${job.state.kind}`,
                 );
               }
             }
@@ -1053,7 +1060,7 @@ function asyncSyscallImpl(db: DatabaseFake) {
             } catch (error) {
               console.error(
                 `Error when running scheduled function ${name}`,
-                error
+                error,
               );
               db.patch(jobId, {
                 state: { kind: "failed" },
@@ -1065,14 +1072,14 @@ function asyncSyscallImpl(db: DatabaseFake) {
               const job = db.get(jobId) as ScheduledFunction;
               if (job.state.kind !== "inProgress") {
                 throw new Error(
-                  `\`convexTest\` invariant error: Unexpected scheduled function state after it finished running: ${job.state.kind}`
+                  `\`convexTest\` invariant error: Unexpected scheduled function state after it finished running: ${job.state.kind}`,
                 );
               }
             }
             db.patch(jobId, { state: { kind: "success" } });
             db.jobFinished(jobId);
           }) as () => void,
-          tsInSecs * 1000 - Date.now()
+          tsInSecs * 1000 - Date.now(),
         );
         return JSON.stringify(convexToJson(jobId));
       }
@@ -1092,7 +1099,7 @@ function asyncSyscallImpl(db: DatabaseFake) {
           // Probably an unintentional implementation in Convex
           // where expressions is only a single expression
           expressions === null ? [] : [expressions],
-          limit
+          limit,
         );
         return JSON.stringify(convexToJson({ results }));
       }
@@ -1130,7 +1137,7 @@ function asyncSyscallImpl(db: DatabaseFake) {
       }
       default: {
         throw new Error(
-          `\`convexTest\` does not support async syscall: "${op}"`
+          `\`convexTest\` does not support async syscall: "${op}"`,
         );
       }
     }
@@ -1184,7 +1191,7 @@ async function blobSha(blob: Blob) {
 async function waitForInProgressScheduledFunctions(): Promise<boolean> {
   const inProgressJobs = (await withAuth().run(async (ctx) => {
     return (await ctx.db.system.query("_scheduled_functions").collect()).filter(
-      (job: ScheduledFunction) => job.state.kind === "inProgress"
+      (job: ScheduledFunction) => job.state.kind === "inProgress",
     );
   })) as ScheduledFunction[];
   let numRemaining = inProgressJobs.length;
@@ -1257,8 +1264,8 @@ export type TestConvexForDataModel<DataModel extends GenericDataModel> = {
    */
   run: <Output>(
     func: (
-      ctx: GenericMutationCtx<DataModel> & { storage: StorageActionWriter }
-    ) => Promise<Output>
+      ctx: GenericMutationCtx<DataModel> & { storage: StorageActionWriter },
+    ) => Promise<Output>,
   ) => Promise<Output>;
 
   /**
@@ -1297,7 +1304,7 @@ export type TestConvexForDataModel<DataModel extends GenericDataModel> = {
 };
 
 export type TestConvexForDataModelAndIdentity<
-  DataModel extends GenericDataModel
+  DataModel extends GenericDataModel,
 > = {
   /**
    * To test functions which depend on the current authenticated user identity
@@ -1308,7 +1315,7 @@ export type TestConvexForDataModelAndIdentity<
    *   generated automatically.
    */
   withIdentity(
-    identity: Partial<UserIdentity>
+    identity: Partial<UserIdentity>,
   ): TestConvexForDataModel<DataModel>;
 } & TestConvexForDataModel<DataModel>;
 
@@ -1331,13 +1338,13 @@ function moduleCache(specifiedModules?: Record<string, () => Promise<any>>) {
   const modules = specifiedModules ?? import.meta.glob("./convex/**/*.*s");
   const prefix = findModulesRoot(
     Object.keys(modules),
-    specifiedModules !== undefined
+    specifiedModules !== undefined,
   );
   const modulesWithoutExtension = Object.fromEntries(
     Object.entries(modules).map(([path, module]) => [
       path.replace(/\.[^.]+$/, ""),
       module,
-    ])
+    ]),
   );
   return async (path: string) => {
     const module = modulesWithoutExtension[prefix + path];
@@ -1350,7 +1357,7 @@ function moduleCache(specifiedModules?: Record<string, () => Promise<any>>) {
 
 function findModulesRoot(modulesPaths: string[], userProvidedModules: boolean) {
   const generatedFilePath = modulesPaths.find((path) =>
-    path.includes("_generated")
+    path.includes("_generated"),
   );
   if (generatedFilePath !== undefined) {
     return generatedFilePath.split("_generated", 2)[0];
@@ -1364,7 +1371,7 @@ function findModulesRoot(modulesPaths: string[], userProvidedModules: boolean) {
           '"_generated" directory'
         : "If your Convex functions aren't defined in a directory " +
           'called "convex" sibling to your node_modules, ' +
-          "provide the second argument to `convexTest`")
+          "provide the second argument to `convexTest`"),
   );
 }
 
@@ -1382,7 +1389,7 @@ function findModulesRoot(modulesPaths: string[], userProvidedModules: boolean) {
 export const convexTest = <Schema extends GenericSchema>(
   schema?: SchemaDefinition<Schema, boolean>,
   // For example `import.meta.glob("./**/*.*s")`
-  modules?: Record<string, () => Promise<any>>
+  modules?: Record<string, () => Promise<any>>,
 ): TestConvex<SchemaDefinition<Schema, boolean>> => {
   const db = new DatabaseFake(schema ?? null);
   (global as unknown as { Convex: any }).Convex = {
@@ -1401,7 +1408,7 @@ export const convexTest = <Schema extends GenericSchema>(
       const tokenIdentifier =
         identity.tokenIdentifier ?? `${issuer}|${subject}`;
       return withAuth(
-        new AuthFake({ ...identity, subject, issuer, tokenIdentifier })
+        new AuthFake({ ...identity, subject, issuer, tokenIdentifier }),
       );
     },
     ...withAuth(),
@@ -1412,7 +1419,7 @@ function withAuth(auth: AuthFake = new AuthFake()) {
   const runTransaction = async <T>(
     handler: (ctx: any, args: any) => T,
     args: any,
-    extraCtx: any = {}
+    extraCtx: any = {},
   ): Promise<T> => {
     const m = mutationGeneric({
       handler: (ctx: any, a: any) => {
@@ -1457,7 +1464,7 @@ function withAuth(auth: AuthFake = new AuthFake()) {
     mutation: async (functionReference: any, args: any): Promise<Value> => {
       const func = await getFunctionFromReference(
         functionReference,
-        "mutation"
+        "mutation",
       );
       validateValidator(JSON.parse(func.exportArgs()), args ?? {});
       return await runTransaction(func, args);
@@ -1487,7 +1494,7 @@ function withAuth(auth: AuthFake = new AuthFake()) {
         }
       ).invokeAction(
         requestId,
-        JSON.stringify(convexToJson([parseArgs(args)]))
+        JSON.stringify(convexToJson([parseArgs(args)])),
       );
       return jsonToConvex(JSON.parse(rawResult));
     },
@@ -1565,7 +1572,7 @@ function withAuth(auth: AuthFake = new AuthFake()) {
     },
 
     finishAllScheduledFunctions: async (
-      advanceTimers: () => void
+      advanceTimers: () => void,
     ): Promise<void> => {
       let hadScheduledFunctions;
       do {
@@ -1577,7 +1584,7 @@ function withAuth(auth: AuthFake = new AuthFake()) {
 }
 
 function parseArgs(
-  args: Record<string, Value> | undefined
+  args: Record<string, Value> | undefined,
 ): Record<string, Value> {
   if (args === undefined) {
     return {};
@@ -1586,7 +1593,7 @@ function parseArgs(
     throw new Error(
       `The arguments to a Convex function must be an object. Received: ${
         args as any
-      }`
+      }`,
     );
   }
   return args;
@@ -1594,14 +1601,14 @@ function parseArgs(
 
 async function getFunctionFromReference(
   functionReference: FunctionReference<any, any, any, any>,
-  type: "query" | "mutation" | "action" | "any"
+  type: "query" | "mutation" | "action" | "any",
 ) {
   return await getFunctionFromName(getFunctionName(functionReference), type);
 }
 
 async function getFunctionFromName(
   functionName: string,
-  type: "query" | "mutation" | "action" | "any"
+  type: "query" | "mutation" | "action" | "any",
 ) {
   // api.foo.bar.default -> `foo/bar`
   const [modulePath, maybeExportName] = functionName.split(":");
@@ -1613,33 +1620,33 @@ async function getFunctionFromName(
   const func = module[exportName];
   if (func === undefined) {
     throw new Error(
-      `Expected a Convex function exported from module "${modulePath}" as \`${exportName}\`, but there is no such export.`
+      `Expected a Convex function exported from module "${modulePath}" as \`${exportName}\`, but there is no such export.`,
     );
   }
   if (typeof func !== "function") {
     throw new Error(
-      `Expected a Convex function exported from module "${modulePath}" as \`${exportName}\`, but got: ${func}`
+      `Expected a Convex function exported from module "${modulePath}" as \`${exportName}\`, but got: ${func}`,
     );
   }
   switch (type) {
     case "query":
       if (!func.isQuery) {
         throw new Error(
-          `Expected a query function, but the function exported from module "${modulePath}" as \`${exportName}\` is not a query.`
+          `Expected a query function, but the function exported from module "${modulePath}" as \`${exportName}\` is not a query.`,
         );
       }
       break;
     case "mutation":
       if (!func.isMutation) {
         throw new Error(
-          `Expected a mutation function, but the function exported from module "${modulePath}" as \`${exportName}\` is not a mutation.`
+          `Expected a mutation function, but the function exported from module "${modulePath}" as \`${exportName}\` is not a mutation.`,
         );
       }
       break;
     case "action":
       if (!func.isAction) {
         throw new Error(
-          `Expected an action function, but the function exported from module "${modulePath}" as \`${exportName}\` is not an action.`
+          `Expected an action function, but the function exported from module "${modulePath}" as \`${exportName}\` is not an action.`,
         );
       }
       break;


### PR DESCRIPTION
suppose there are three transactions trying to execute in parallel.
the first one sets `_waitOnCurrentFunction` and starts running.
the other two await `_waitOnCurrentFunction`. when the first transaction finishes, the other two start running, without waiting for each other.

using a `while` loop is the standard pattern when waiting for a condition variable, so it seems fine to use it here.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
