### PR TITLE
Nipunn/fix gt lt on single field

### DIFF
--- a/convex/indexes.test.ts
+++ b/convex/indexes.test.ts
@@ -48,7 +48,7 @@ test("index must use only its fields, by_creation_time", async () => {
 
 // TypeScript won't let you do this because we wanted
 // to keep the types simple, but it is runtime-wise correct.
-test("_id is always last indexed field", async () => {
+test("_id is always last indexed field gt gt", async () => {
   const t = convexTest(schema);
   await t.run(async (ctx) => {
     // do not throw
@@ -59,6 +59,88 @@ test("_id is always last indexed field", async () => {
           "_id",
           "someId",
         ),
+      )
+      .collect();
+  });
+});
+
+// TypeScript won't let you do this because we wanted
+// to keep the types simple, but it is runtime-wise correct.
+test("_id is always last indexed field lt lt", async () => {
+  const t = convexTest(schema);
+  await t.run(async (ctx) => {
+    // do not throw
+    await ctx.db
+      .query("messages")
+      .withIndex("author", (q) =>
+        (q.eq("author", "sarah").lt("_creationTime", 3) as any).lt(
+          "_id",
+          "someId",
+        ),
+      )
+      .collect();
+  });
+});
+
+// TypeScript won't let you do this because we wanted
+// to keep the types simple, but it is runtime-wise correct.
+test("_id is always last indexed field lt gt", async () => {
+  const t = convexTest(schema);
+  await t.run(async (ctx) => {
+    // do not throw
+    await ctx.db
+      .query("messages")
+      .withIndex("author", (q) =>
+        (q.eq("author", "sarah").lt("_creationTime", 3) as any).gt(
+          "_id",
+          "someId",
+        ),
+      )
+      .collect();
+  });
+});
+
+// TypeScript won't let you do this because we wanted
+// to keep the types simple, but it is runtime-wise correct.
+test("_id is always last indexed field gt lt", async () => {
+  const t = convexTest(schema);
+  await t.run(async (ctx) => {
+    // do not throw
+    await ctx.db
+      .query("messages")
+      .withIndex("author", (q) =>
+        (q.eq("author", "sarah").gt("_creationTime", 3) as any).lt(
+          "_id",
+          "someId",
+        ),
+      )
+      .collect();
+  });
+});
+
+test("gt,lt in range of indexed field", async () => {
+  const t = convexTest(schema);
+  await t.run(async (ctx) => {
+    // do not throw
+    await ctx.db
+      .query("messages")
+      .withIndex("author", (q) =>
+        q.gt("author", "nipunn").lt("author", "sarah"),
+      )
+      .collect();
+  });
+});
+
+// TypeScript won't let you do this because we wanted
+// to keep the types simple, but it is runtime-wise correct.
+test("lt,gt in range of indexed field", async () => {
+  const t = convexTest(schema);
+  await t.run(async (ctx) => {
+    // do not throw
+    await ctx.db
+      .query("messages")
+      .withIndex("author", (q) =>
+        (q.lt("author", "nipunn") as any).gt("author", "sarah"),
       )
       .collect();
   });


### PR DESCRIPTION
    Fix `.withIndex` to work for multiple clauses on a single field

    Added several tests for these scenarios.
    Allow the next index clause to go on the same field or the next field.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
