### PR TITLE
Fix indexing query builder to match production convex

### DIFF
--- a/convex/indexes.test.ts
+++ b/convex/indexes.test.ts
@@ -46,75 +46,79 @@ test("index must use only its fields, by_creation_time", async () => {
   });
 });
 
-// TypeScript won't let you do this because we wanted
-// to keep the types simple, but it is runtime-wise correct.
+// TypeScript won't let you run into this error
 test("_id is always last indexed field gt gt", async () => {
   const t = convexTest(schema);
   await t.run(async (ctx) => {
-    // do not throw
-    await ctx.db
-      .query("messages")
-      .withIndex("author", (q) =>
-        (q.eq("author", "sarah").gt("_creationTime", 3) as any).gt(
-          "_id",
-          "someId",
-        ),
-      )
-      .collect();
+    await expect(
+      async () =>
+        await ctx.db
+          .query("messages")
+          .withIndex("author", (q) =>
+            (q.eq("author", "sarah").gt("_creationTime", 3) as any).gt(
+              "_id",
+              "someId",
+            ),
+          )
+          .collect(),
+    ).rejects.toThrow();
   });
 });
 
-// TypeScript won't let you do this because we wanted
-// to keep the types simple, but it is runtime-wise correct.
+// TypeScript won't let you run into this error
 test("_id is always last indexed field lt lt", async () => {
   const t = convexTest(schema);
   await t.run(async (ctx) => {
-    // do not throw
-    await ctx.db
-      .query("messages")
-      .withIndex("author", (q) =>
-        (q.eq("author", "sarah").lt("_creationTime", 3) as any).lt(
-          "_id",
-          "someId",
-        ),
-      )
-      .collect();
+    await expect(
+      async () =>
+        await ctx.db
+          .query("messages")
+          .withIndex("author", (q) =>
+            (q.eq("author", "sarah").lt("_creationTime", 3) as any).lt(
+              "_id",
+              "someId",
+            ),
+          )
+          .collect(),
+    ).rejects.toThrow();
   });
 });
 
-// TypeScript won't let you do this because we wanted
-// to keep the types simple, but it is runtime-wise correct.
+// TypeScript won't let you run into this error
 test("_id is always last indexed field lt gt", async () => {
   const t = convexTest(schema);
   await t.run(async (ctx) => {
-    // do not throw
-    await ctx.db
-      .query("messages")
-      .withIndex("author", (q) =>
-        (q.eq("author", "sarah").lt("_creationTime", 3) as any).gt(
-          "_id",
-          "someId",
-        ),
-      )
-      .collect();
+    await expect(
+      async () =>
+        await ctx.db
+          .query("messages")
+          .withIndex("author", (q) =>
+            (q.eq("author", "sarah").lt("_creationTime", 3) as any).gt(
+              "_id",
+              "someId",
+            ),
+          )
+          .collect(),
+    ).rejects.toThrow();
   });
 });
 
-// TypeScript won't let you do this because we wanted
-// to keep the types simple, but it is runtime-wise correct.
+// TypeScript won't let you run into this error
 test("_id is always last indexed field gt lt", async () => {
   const t = convexTest(schema);
   await t.run(async (ctx) => {
-    // do not throw
-    await ctx.db
-      .query("messages")
-      .withIndex("author", (q) =>
-        (q.eq("author", "sarah").gt("_creationTime", 3) as any).lt(
-          "_id",
-          "someId",
-        ),
-      )
-      .collect();
+    await expect(
+      async () =>
+        await ctx.db
+          .query("messages")
+          .withIndex("author", (q) =>
+            (q.eq("author", "sarah").gt("_creationTime", 3) as any).lt(
+              "_id",
+              "someId",
+            ),
+          )
+          .collect(),
+    ).rejects.toThrow();
   });
 });
 
@@ -133,6 +137,7 @@ test("gt,lt in range of indexed field", async () => {
 
 // TypeScript won't let you do this because we wanted
 // to keep the types simple, but it is runtime-wise correct.
+// Typescript makes you do gt before lt
 test("lt,gt in range of indexed field", async () => {
   const t = convexTest(schema);
   await t.run(async (ctx) => {
@@ -143,5 +148,24 @@ test("lt,gt in range of indexed field", async () => {
         (q.lt("author", "nipunn") as any).gt("author", "sarah"),
       )
       .collect();
+  });
+});
+
+// TypeScript won't let you run into this error
+test("gt,lt,lt in range of indexed field", async () => {
+  const t = convexTest(schema);
+  await t.run(async (ctx) => {
+    await expect(
+      async () =>
+        await ctx.db
+          .query("messages")
+          .withIndex("author", (q) =>
+            (q.gt("author", "nipunn").lt("author", "sarah") as any).gt(
+              "author",
+              "aaa",
+            ),
+          )
+          .collect(),
+    ).rejects.toThrow("Cannot add more clauses after gt/lt");
   });
 });

--- a/index.ts
+++ b/index.ts
@@ -461,7 +461,7 @@ class DatabaseFake {
         // [Optionally] A lower bound expression defined with .gt or .gte.
         // [Optionally] An upper bound expression defined with .lt or .lte.
         let fieldIdx = 0;
-        let state: "empty" | "eq" | "gt" | "lt" | "done" = "empty";
+        let state: "eq" | "gt" | "lt" | "done" = "eq";
         for (const filter of source.range) {
           if (state === "done") {
             throw new Error("Cannot add more clauses after gt/lt");
@@ -476,9 +476,6 @@ class DatabaseFake {
 
           switch (`${state}|${filterType}`) {
             // Allow to operate on the current indexed field
-            case "empty|eq":
-            case "empty|gt":
-            case "empty|lt":
             case "eq|eq":
             case "eq|gt":
             case "eq|lt":

--- a/index.ts
+++ b/index.ts
@@ -461,15 +461,46 @@ class DatabaseFake {
         // [Optionally] A lower bound expression defined with .gt or .gte.
         // [Optionally] An upper bound expression defined with .lt or .lte.
         let fieldIdx = 0;
-        for (const [i, filter] of source.range.entries()) {
-          // Allow to operate on same field (again)
-          if (i > 0 && filter.fieldPath === source.range[i - 1].fieldPath) {
-            continue;
+        let state: "empty" | "eq" | "gt" | "lt" | "done" = "empty";
+        for (const filter of source.range) {
+          if (state === "done") {
+            throw new Error("Cannot add more clauses after gt/lt");
           }
-          // Allow to operate on the current indexed field
-          if (filter.fieldPath === fields[fieldIdx]) {
-            fieldIdx += 1;
-            continue;
+
+          let filterType: "eq" | "gt" | "lt" =
+            filter.type == "Gt" || filter.type == "Gte"
+              ? "gt"
+              : filter.type == "Lt" || filter.type == "Lte"
+                ? "lt"
+                : "eq";
+
+          switch (`${state}|${filterType}`) {
+            // Allow to operate on the current indexed field
+            case "empty|eq":
+            case "empty|gt":
+            case "empty|lt":
+            case "eq|eq":
+            case "eq|gt":
+            case "eq|lt":
+              if (filter.fieldPath === fields[fieldIdx]) {
+                fieldIdx += 1;
+                state = filterType;
+                continue;
+              }
+              break;
+
+            // Allow to operate on the previous field (gt and lt must operate on same field)
+            case "lt|gt":
+            case "gt|lt":
+              if (fieldIdx > 0 && filter.fieldPath === fields[fieldIdx - 1]) {
+                state = "done";
+                continue;
+              }
+              throw new Error(
+                `gt and lt must operate on same field in withIndex`,
+              );
+
+            // everything else disallowed
           }
 
           throw new Error(


### PR DESCRIPTION
Disallow .gt.gt on separate fields. gt and lt must be on the same field. It fails at runtime in production if we try.

Fix the tests to check for rejects. Fix the code to reject those cases.=


<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
