### PR TITLE
fix `db.patch(id, {foo: undefined})`

### DIFF
--- a/convex/mutations.test.ts
+++ b/convex/mutations.test.ts
@@ -87,6 +87,26 @@ test("patch after insert", async () => {
   expect(messages).toMatchObject([{ body: "hi", author: "sarah" }]);
 });
 
+test("patch undefined", async () => {
+  const t = convexTest(schema);
+  const messages = await t.run(async (ctx) => {
+    const id = await ctx.db.insert("messages", {
+      body: "hello",
+      author: "sarah",
+      embedding: [1, 1, 1],
+    });
+    await ctx.db.patch(id, { body: "hi", embedding: undefined });
+    return ctx.db.query("messages").collect();
+  });
+  expect(messages).toHaveLength(1);
+  // NOTE can't use toMatchObject because missing field is significant.
+  const { body, author, embedding } = messages[0];
+  expect(body).toStrictEqual("hi");
+  expect(author).toStrictEqual("sarah");
+  expect(embedding).toBeUndefined();
+});
+
+
 test("replace after insert", async () => {
   const t = convexTest(schema);
   const messages = await t.run(async (ctx) => {

--- a/index.ts
+++ b/index.ts
@@ -258,6 +258,11 @@ class DatabaseFake {
     }
     delete value["_id"];
     delete value["_creationTime"];
+    for (const [key, v] of Object.entries(value)) {
+      if (v['$undefined'] === null) {
+        value[key] = undefined;
+      }
+    }
     const merged = { ...fields, ...value };
     this._validate(tableNameFromId(_id as string)!, merged);
     this._writes[id] = {


### PR DESCRIPTION
<!-- Describe your PR here. -->

allow `db.patch` to use `undefined` at the top level to clear a field. this matches the behavior of prod convex.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
