### PR TITLE
fix value serde in `patch`, comparison of complex values

### DIFF
--- a/compare.ts
+++ b/compare.ts
@@ -1,0 +1,85 @@
+import { Value } from "convex/values";
+
+// Returns -1 if k1 < k2
+// Returns 0 if k1 === k2
+// Returns 1 if k1 > k2
+export function compareValues(k1: Value | undefined, k2: Value | undefined) {
+  return compareAsTuples(makeComparable(k1), makeComparable(k2));
+}
+
+function compareAsTuples<T>(a: [number, T], b: [number, T]): number {
+  if (a[0] === b[0]) {
+    return compareSameTypeValues(a[1], b[1]);
+  } else if (a[0] < b[0]) {
+    return -1;
+  }
+  return 1;
+}
+
+function compareSameTypeValues<T>(v1: T, v2: T): number {
+  if (v1 === undefined || v1 === null) {
+    return 0;
+  }
+  if (
+    typeof v1 === "bigint"
+    || typeof v1 === "number"
+    || typeof v1 === "boolean"
+    || typeof v1 === "string"
+  ) {
+    return v1 < v2 ? -1 : v1 === v2 ? 0 : 1;
+  }
+  if (!Array.isArray(v1) || !Array.isArray(v2)) {
+    throw new Error(`Unexpected type ${v1 as any}`);
+  }
+  for (let i = 0; i < v1.length && i < v2.length; i++) {
+    const cmp = compareAsTuples(v1[i], v2[i]);
+    if (cmp !== 0) {
+      return cmp;
+    }
+  }
+  if (v1.length < v2.length) {
+    return -1;
+  }
+  if (v1.length > v2.length) {
+    return 1;
+  }
+  return 0;
+}
+
+// Returns an array which can be compared to other arrays as if they were tuples.
+// For example, [1, null] < [2, 1n] means null sorts before all bigints
+// And [3, 5] < [3, 6] means floats sort as expected
+// And [7, [[5, "a"]]] < [7, [[5, "a"], [5, "b"]]] means arrays sort as expected
+function makeComparable(v: Value | undefined): [number, any] {
+  if (v === undefined) {
+    return [0, undefined];
+  }
+  if (v === null) {
+    return [1, null];
+  }
+  if (typeof v === "bigint") {
+    return [2, v];
+  }
+  if (typeof v === "number") {
+    if (isNaN(v)) { // Consider all NaNs to be equal.
+      return [3.5, 0];
+    }
+    return [3, v];
+  }
+  if (typeof v === "boolean") {
+    return [4, v];
+  }
+  if (typeof v === "string") {
+    return [5, v];
+  }
+  if (v instanceof ArrayBuffer) {
+    return [6, Array.from(new Uint8Array(v)).map(makeComparable)];
+  }
+  if (Array.isArray(v)) {
+    return [7, v.map(makeComparable)];
+  }
+  // Otherwise, it's an POJO.
+  const keys = Object.keys(v).sort();
+  const pojo: Value[] = keys.map((k) => [k, v[k]!]);
+  return [8, pojo.map(makeComparable)];
+}

--- a/convex/messages.test.ts
+++ b/convex/messages.test.ts
@@ -57,6 +57,12 @@ test("all types serde", async () => {
         .unique();
       expect(byIndex).not.toBeNull();
       expectBodiesEq(byIndex!.body, body);
+      // Filtered db.query
+      const byFilter = await ctx.db.query("messages")
+        .filter(q=>q.eq(q.field("body"), body))
+        .unique();
+      expect(byFilter).not.toBeNull();
+      expectBodiesEq(byFilter!.body, body);
       // Patch
       await ctx.db.patch(id, { body });
       expectBodiesEq((await ctx.db.get(id))!.body, body);
@@ -74,16 +80,16 @@ test("all types serde", async () => {
     await testBody(undefined);
     await testBody(true);
     await testBody(35);
-    // await testBody(BigInt(34));
-    // await testBody(null);
-    // await testBody(["a"]);
-    // await testBody([BigInt(34)]);
-    // await testBody({ a: 1 });
-    // await testBody({ a: BigInt(34) });
-    // await testBody(new ArrayBuffer(8));
-    // await testBody(Number.POSITIVE_INFINITY);
-    // await testBody(Number.NEGATIVE_INFINITY);
-    // await testBody(-0.0);
-    // await testBody(NaN);
+    await testBody(BigInt(34));
+    await testBody(null);
+    await testBody(["a"]);
+    await testBody([BigInt(34)]);
+    await testBody({ a: 1 });
+    await testBody({ a: BigInt(34) });
+    await testBody(new ArrayBuffer(8));
+    await testBody(Number.POSITIVE_INFINITY);
+    await testBody(Number.NEGATIVE_INFINITY);
+    await testBody(-0.0);
+    await testBody(NaN);
   });
 });

--- a/convex/messages.test.ts
+++ b/convex/messages.test.ts
@@ -2,6 +2,8 @@ import { expect, test, vi } from "vitest";
 import { convexTest } from "../index";
 import { api } from "./_generated/api";
 import schema from "./schema";
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
 
 test("messages", async () => {
   const t = convexTest(schema);
@@ -26,4 +28,63 @@ test("ai", async () => {
   const messages = await t.query(api.messages.list);
   expect(messages).toMatchObject([{ author: "AI", body: "I am the overlord" }]);
   vi.unstubAllGlobals();
+});
+
+test("all types serde", async () => {
+  const relaxedSchema = defineSchema({
+    messages: defineTable({
+      body: v.optional(v.any()),
+    }).index("body", ["body"]),
+  });
+  const t = convexTest(relaxedSchema);
+  const bodies: any[] = [
+    "stringValue",
+    undefined,
+    true,
+    35,
+    BigInt(34),
+    null,
+    ["a"],
+    [BigInt(34)],
+    { a: 1 },
+    { a: BigInt(34) },
+    new ArrayBuffer(8),
+    Number.POSITIVE_INFINITY,
+    Number.NEGATIVE_INFINITY,
+    -0.0,
+    NaN,
+  ];
+  const messages = await t.run(async (ctx) => {
+    await Promise.all(
+      bodies.map(async (body) => {
+        await ctx.db.insert("messages", { body });
+      }),
+    );
+    return await ctx.db.query("messages").collect();
+  });
+  const expectBodiesEq = (a: any, b: any) => {
+    if (a === undefined) {
+      expect(b).toBeUndefined();
+    } else {
+      expect(b).toMatchObject(a);
+    }
+  };
+  await t.run(async (ctx) => {
+    for (const message of messages) {
+      // Simple db.get
+      const byGet = await ctx.db.get(message._id);
+      expect(byGet).not.toBeNull();
+      expectBodiesEq(byGet!.body, message.body);
+      // Indexed db.query
+      const byIndex = await ctx.db.query("messages").withIndex("body", q=>q.eq("body", message.body)).unique();
+      expect(byIndex).not.toBeNull();
+      expectBodiesEq(byIndex!.body, message.body);
+      // Patch
+      await ctx.db.patch(message._id, { body: message.body });
+      expectBodiesEq((await ctx.db.get(message._id))!.body, message.body);
+      // Replace
+      await ctx.db.replace(message._id, { body: message.body });
+      expectBodiesEq((await ctx.db.get(message._id))!.body, message.body);
+    }
+  });
 });

--- a/index.ts
+++ b/index.ts
@@ -30,6 +30,7 @@ import {
   jsonToConvex,
 } from "convex/values";
 import { createHash } from "crypto";
+import { compareValues } from "./compare";
 
 type FilterJson =
   | { $eq: [FilterJson, FilterJson] }
@@ -258,12 +259,15 @@ class DatabaseFake {
     }
     delete value["_id"];
     delete value["_creationTime"];
+    const convexValue: any = {};
     for (const [key, v] of Object.entries(value)) {
-      if (v['$undefined'] === null) {
-        value[key] = undefined;
+      if (v !== null && v['$undefined'] === null) {
+        convexValue[key] = undefined;
+      } else {
+        convexValue[key] = jsonToConvex(v);
       }
     }
-    const merged = { ...fields, ...value };
+    const merged = { ...fields, ...convexValue };
     this._validate(tableNameFromId(_id as string)!, merged);
     this._writes[id] = {
       newValue: { _id, _creationTime, ...merged },
@@ -293,10 +297,14 @@ class DatabaseFake {
     }
     delete value["_id"];
     delete value["_creationTime"];
-    this._validate(tableNameFromId(document._id as string)!, value);
+    const convexValue: any = {};
+    for (const [key, v] of Object.entries(value)) {
+      convexValue[key] = jsonToConvex(v);
+    }
+    this._validate(tableNameFromId(document._id as string)!, convexValue);
     this._writes[id] = {
       newValue: {
-        ...value,
+        ...convexValue,
         _id: document._id,
         _creationTime: document._creationTime,
       },
@@ -586,68 +594,6 @@ function tableNameFromId(id: string) {
   return id.split(";")[1];
 }
 
-function compareValues(a: Value | undefined, b: Value | undefined) {
-  if (a === b) {
-    return 0;
-  }
-  if (a === undefined) {
-    return -1;
-  }
-  if (b === undefined) {
-    return 1;
-  }
-  if (a === null) {
-    return -1;
-  }
-  if (b === null) {
-    return 1;
-  }
-  const aType = typeof a;
-  const bType = typeof b;
-  if (aType !== bType) {
-    if (aType === "bigint") {
-      return -1;
-    }
-    if (bType === "bigint") {
-      return 1;
-    }
-    if (aType === "number") {
-      return -1;
-    }
-    if (bType === "number") {
-      return 1;
-    }
-    if (aType === "boolean") {
-      return -1;
-    }
-    if (bType === "boolean") {
-      return 1;
-    }
-    if (aType === "string") {
-      return -1;
-    }
-    if (bType === "string") {
-      return 1;
-    }
-  }
-  if (aType === "object") {
-    if (a instanceof ArrayBuffer && !(b instanceof ArrayBuffer)) {
-      return -1;
-    }
-    if (b instanceof ArrayBuffer && !(a instanceof ArrayBuffer)) {
-      return 1;
-    }
-    if (Array.isArray(a) && !Array.isArray(b)) {
-      return -1;
-    }
-    if (Array.isArray(b) && !Array.isArray(a)) {
-      return 1;
-    }
-  }
-
-  return a < b ? -1 : 1;
-}
-
 function isSimpleObject(value: unknown) {
   const isObject = typeof value === "object";
   const prototype = Object.getPrototypeOf(value);
@@ -677,16 +623,16 @@ function evaluateFilter(
   filter: any,
 ): Value | undefined {
   if (filter.$eq !== undefined) {
-    return (
-      evaluateFilter(document, filter.$eq[0]) ===
+    return compareValues(
+      evaluateFilter(document, filter.$eq[0]),
       evaluateFilter(document, filter.$eq[1])
-    );
+    ) === 0;
   }
   if (filter.$neq !== undefined) {
-    return (
-      evaluateFilter(document, filter.$neq[0]) !==
+    return compareValues(
+      evaluateFilter(document, filter.$neq[0]),
       evaluateFilter(document, filter.$neq[1])
-    );
+    ) !== 0;
   }
   if (filter.$and !== undefined) {
     return filter.$and.every((child: any) => evaluateFilter(document, child));
@@ -768,15 +714,15 @@ function evaluateRangeFilter(
   const value = evaluateValue(expr.value);
   switch (expr.type) {
     case "Eq":
-      return result === value;
+      return compareValues(result, value) === 0;
     case "Gt":
-      return (result as any) > (value as any);
+      return compareValues(result, value) > 0;
     case "Gte":
-      return (result as any) >= (value as any);
+      return compareValues(result, value) >= 0;
     case "Lt":
-      return (result as any) < (value as any);
+      return compareValues(result, value) < 0;
     case "Lte":
-      return (result as any) <= (value as any);
+      return compareValues(result, value) <= 0;
   }
 }
 
@@ -784,7 +730,7 @@ function evaluateValue(value: JSONValue) {
   if (typeof value === "object" && value !== null && "$undefined" in value) {
     return undefined;
   }
-  return value;
+  return jsonToConvex(value);
 }
 
 function evaluateSearchFilter(
@@ -794,7 +740,7 @@ function evaluateSearchFilter(
   const result = evaluateFieldPath(filter.fieldPath, document);
   switch (filter.type) {
     case "Eq":
-      return result === filter.value;
+      return compareValues(result, filter.value) === 0;
     case "Search":
       return (result as string)
         .split(/\s/)

--- a/index.ts
+++ b/index.ts
@@ -261,11 +261,7 @@ class DatabaseFake {
     delete value["_creationTime"];
     const convexValue: any = {};
     for (const [key, v] of Object.entries(value)) {
-      if (v !== null && v['$undefined'] === null) {
-        convexValue[key] = undefined;
-      } else {
-        convexValue[key] = jsonToConvex(v);
-      }
+      convexValue[key] = evaluateValue(v);
     }
     const merged = { ...fields, ...convexValue };
     this._validate(tableNameFromId(_id as string)!, merged);
@@ -299,7 +295,7 @@ class DatabaseFake {
     delete value["_creationTime"];
     const convexValue: any = {};
     for (const [key, v] of Object.entries(value)) {
-      convexValue[key] = jsonToConvex(v);
+      convexValue[key] = evaluateValue(v);
     }
     this._validate(tableNameFromId(document._id as string)!, convexValue);
     this._writes[id] = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,6 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true
   },
-  "include": ["./index.ts"],
+  "include": ["./*.ts"],
   "exclude": ["convex"]
 }


### PR DESCRIPTION
<!-- Describe your PR here. -->

`patch` and `replace` were not using `jsonToConvex`, so if you did `db.patch(id, { foo: BigInt(1) })` and then `db.get(id)` it would throw an error because of the field name "$integer".

also fixes a bug i recently caused where `db.patch(id, { foo: null })` would throw an error; whoops.

fix comparisons for complex values like `BigInt` and arrays, which weren't working, by copying the compare.ts function from the aggregate component. that library isn't perfect, for example i think it considers -0 and +0 to be equal, but it's better than the existing `compareValues` function which thinks `["a"] < ["a"]` and `{a:null} < {a: null}`

added a test that covers all of the operations for all kinds of values.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
