### PR TITLE
mutations can read their own deletes

### DIFF
--- a/convex/mutations.test.ts
+++ b/convex/mutations.test.ts
@@ -136,3 +136,17 @@ test("concurrent append", async () => {
   // message becomes "hello!!".
   expect(messages).toMatchObject([{ body: "hello!!!!!!!!!!", author: "lee" }]);
 });
+
+test("delete is visible in transaction", async () => {
+  const t = convexTest(schema);
+  const id = await t.run(async (ctx) => {
+    return await ctx.db.insert("messages", { body: "hello", author: "sarah" });
+  });
+  await t.run(async (ctx) => {
+    await ctx.db.delete(id);
+    expect(await ctx.db.get(id)).toBeNull();
+    const first = await ctx.db.query("messages").first();
+    // Regression test: this used to still exist even after delete.
+    expect(first).toBeNull();
+  });
+});

--- a/index.ts
+++ b/index.ts
@@ -418,10 +418,10 @@ class DatabaseFake {
     for (const document of Object.values(this._documents)) {
       if (tableNameFromId(document._id) === tableName) {
         const write = this._writes[document._id];
-        if (write !== undefined && !write.isInsert && write.newValue !== null) {
-          callback(write.newValue);
-        } else {
+        if (write === undefined) {
           callback(document);
+        } else if (!write.isInsert && write.newValue !== null) {
+          callback(write.newValue);
         }
       }
     }


### PR DESCRIPTION
<!-- Describe your PR here. -->

a mutation should be able to delete something and then a subsequent `db.query` in the same transaction should not return it. see regression test. 

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
