### PR TITLE
Call `jsonToConvex` in update & replace syscalls

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1050,12 +1050,12 @@ function asyncSyscallImpl(db: DatabaseFake) {
       }
       case "1.0/shallowMerge": {
         const { id, value } = args;
-        db.patch(id, value);
+        db.patch(id, jsonToConvex(value));
         return JSON.stringify({});
       }
       case "1.0/replace": {
         const { id, value } = args;
-        db.replace(id, value);
+        db.replace(id, jsonToConvex(value));
         return JSON.stringify({});
       }
       case "1.0/remove": {


### PR DESCRIPTION
I ran into the raw `{$bytes: "..."}` object falling through when testing a counter component I'm working on.