### PR TITLE
add timeout to `finishAllScheduledFunctions`

### DIFF
--- a/convex/scheduler.test.ts
+++ b/convex/scheduler.test.ts
@@ -164,3 +164,15 @@ test("failed scheduled function", async () => {
   ]);
   vi.useRealTimers();
 });
+
+test("self-scheduling mutation", async () => {
+  vi.useFakeTimers();
+  const t = convexTest(schema);
+  await t.mutation(api.scheduler.selfSchedulingMutation, {});
+
+  await expect(t.finishAllScheduledFunctions(vi.runAllTimers))
+    .rejects
+    .toThrowError(/Check for infinitely recursive scheduled functions/);
+
+  vi.useRealTimers();
+});

--- a/convex/scheduler.ts
+++ b/convex/scheduler.ts
@@ -99,3 +99,10 @@ export const actionSchedulingActionNTimes = action({
     }
   },
 });
+
+export const selfSchedulingMutation = mutation({
+  args: {},
+  handler: async (ctx) => {
+    await ctx.scheduler.runAfter(1000, api.scheduler.selfSchedulingMutation, {});
+  },
+});

--- a/index.ts
+++ b/index.ts
@@ -1901,12 +1901,21 @@ function withAuth(auth: AuthFake = new AuthFake()) {
 
     finishAllScheduledFunctions: async (
       advanceTimers: () => void,
+      maxIterations: number = 100,
     ): Promise<void> => {
-      let hadScheduledFunctions;
-      do {
+      // Wait for all scheduled functions to finish, advancing time in between
+      // each function.
+      // Stop after a fixed number of iterations to avoid infinite loops.
+      for (let i = 0; i < maxIterations; i++) {
         advanceTimers();
-        hadScheduledFunctions = await waitForInProgressScheduledFunctions();
-      } while (hadScheduledFunctions);
+        const hadScheduledFunctions = await waitForInProgressScheduledFunctions();
+        if (!hadScheduledFunctions) {
+          return;
+        }
+      }
+      throw new Error("finishAllScheduledFunctions: too many iterations. "
+        + "Check for infinitely recursive scheduled functions, "
+        + "or increase maxIterations.");
     },
   };
 }


### PR DESCRIPTION
<!-- Describe your PR here. -->

sometimes you just can't finish the scheduled functions.

instead of deadlocking the test and being annoying to debug because it swallows logs, throw an error.
 
<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
