### PR TITLE
fix arg encoding for component functions

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -79,6 +79,12 @@ export declare const components: {
         {},
         any
       >;
+      mutationWithNumberArg: FunctionReference<
+        "mutation",
+        "internal",
+        { a: number },
+        any
+      >;
       schedule: FunctionReference<
         "mutation",
         "internal",

--- a/convex/argumentsValidation.ts
+++ b/convex/argumentsValidation.ts
@@ -1,5 +1,6 @@
 import { v } from "convex/values";
 import { action, mutation, query } from "./_generated/server";
+import { components } from "./_generated/api";
 
 export const queryWithArgs = query({
   args: {
@@ -40,5 +41,15 @@ export const queryWithOptionalArgs = query({
   },
   handler: () => {
     return "ok";
+  },
+});
+
+export const componentMutationWithNumberArg = mutation({
+  args: { a: v.any() },
+  handler: (ctx, args) => {
+    const result = ctx.runMutation(components.counter.public.mutationWithNumberArg, {
+      a: args.a,
+    });
+    return result;
   },
 });

--- a/counter/component/_generated/api.d.ts
+++ b/counter/component/_generated/api.d.ts
@@ -38,6 +38,12 @@ export type Mounts = {
     >;
     count: FunctionReference<"query", "public", { name: string }, number>;
     mutationWithNestedQuery: FunctionReference<"mutation", "public", {}, any>;
+    mutationWithNumberArg: FunctionReference<
+      "mutation",
+      "public",
+      { a: number },
+      any
+    >;
     schedule: FunctionReference<"mutation", "public", { name: string }, any>;
   };
 };

--- a/counter/component/public.ts
+++ b/counter/component/public.ts
@@ -63,3 +63,10 @@ export const mutationWithNestedQuery = mutation({
     return doc!.value;
   },
 });
+
+export const mutationWithNumberArg = mutation({
+  args: { a: v.number() },
+  handler: async (_ctx, args) => {
+    return args.a;
+  },
+});

--- a/index.ts
+++ b/index.ts
@@ -1093,8 +1093,9 @@ function asyncSyscallImpl() {
           name,
           reference,
           functionHandle,
-          args: udfArgs,
+          args: udfArgsJson,
         } = args;
+        const udfArgs = jsonToConvex(udfArgsJson);
         const functionPath = await getFunctionPathFromAddress({
           name,
           reference,


### PR DESCRIPTION
<!-- Describe your PR here. -->

need to call `jsonToConvex` in the runUdf syscall, otherwise values like Number.POSITIVE_INFINITY don't get passed through correctly.

see regression test.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
