### PR TITLE
avoid "crypto" import so test files can run in non-node runtimes

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -35,7 +35,6 @@ import {
   convexToJson,
   jsonToConvex,
 } from "convex/values";
-import { createHash } from "crypto";
 import { compareValues } from "./compare.js";
 
 type FilterJson =

--- a/index.ts
+++ b/index.ts
@@ -1320,7 +1320,7 @@ async function writeToDatabase<T>(impl: (db: DatabaseFake) => Promise<T>) {
 
 async function blobSha(blob: Blob) {
   const arrayBuffer = await blob.arrayBuffer();
-  const hashBuffer = await crypto.subtle.digest('SHA-256', arrayBuffer);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", arrayBuffer);
   const hashArray = new Uint8Array(hashBuffer);
   return btoa(String.fromCharCode(...hashArray));
 }

--- a/index.ts
+++ b/index.ts
@@ -1321,9 +1321,9 @@ async function writeToDatabase<T>(impl: (db: DatabaseFake) => Promise<T>) {
 
 async function blobSha(blob: Blob) {
   const arrayBuffer = await blob.arrayBuffer();
-  const sha256 = createHash("sha256");
-  sha256.update(Buffer.from(arrayBuffer));
-  return sha256.digest("base64");
+  const hashBuffer = await crypto.subtle.digest('SHA-256', arrayBuffer);
+  const hashArray = new Uint8Array(hashBuffer);
+  return btoa(String.fromCharCode(...hashArray));
 }
 
 async function waitForInProgressScheduledFunctions(): Promise<boolean> {


### PR DESCRIPTION
<!-- Describe your PR here. -->

reduce dependence on node-specific libraries, so convex-test files can be analyzed if they happen to be picked up in a convex deployment, or run with another runtime like deno.

note the webcrypto api in node was stabilized in Node 19, so this bumps the node version dependency for convex-test. If you need to also run a lower version (e.g. for local convex development), we suggest nvm.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
