### PR TITLE
allow system fields in schema

### DIFF
--- a/convex/schema.test.ts
+++ b/convex/schema.test.ts
@@ -25,6 +25,13 @@ test("field names must be identifiers", async () => {
   expect(() => convexTest(schema)).toThrow();
 });
 
+test("accepts _id and _creationTime", async () => {
+  const schema = defineSchema({
+    a: defineTable({ _id: v.string(), _creationTime: v.number() }),
+  });
+  expect(() => convexTest(schema)).not.toThrow();
+});
+
 test("field names must be identifiers union", async () => {
   const schema = defineSchema({
     a: defineTable(

--- a/index.ts
+++ b/index.ts
@@ -843,7 +843,7 @@ function validateFieldNames(validator: ValidatorJSON) {
 }
 
 function isValidIdentifier(name: string) {
-  return /^[a-zA-Z][a-zA-Z0-9_]*$/.test(name);
+  return /(^_(id|creationTime)$)|^[a-zA-Z][a-zA-Z0-9_]*$/.test(name);
 }
 
 type ObjectFieldType = { fieldType: ValidatorJSON; optional: boolean };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "convex-test",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "convex-test",
-      "version": "0.0.35",
+      "version": "0.0.36",
       "license": "Apache-2.0",
       "devDependencies": {
         "@edge-runtime/vm": "^3.2.0",


### PR DESCRIPTION
This aligns with backend behavior. This is already supported in insert/patch/replace mocks, they just aren't allowed by the field validation regex.

Raised in Discord: https://discord.com/channels/1019350475847499849/1373065051828785232/1374273809858695198