### PR TITLE
[Bug fix] Make pagination work with deletes

### DIFF
--- a/convex/pagination.test.ts
+++ b/convex/pagination.test.ts
@@ -55,3 +55,44 @@ test("paginate", async () => {
   expect(page3).toMatchObject([]);
   expect(isDone3).toEqual(true);
 });
+
+test("paginate with deletes", async () => {
+  const t = convexTest(schema);
+  await t.run(async (ctx) => {
+    await ctx.db.insert("messages", { author: "sarah", body: "hello1" });
+    await ctx.db.insert("messages", { author: "michal", body: "boo" });
+    await ctx.db.insert("messages", { author: "sarah", body: "hello2" });
+    await ctx.db.insert("messages", { author: "sarah", body: "hello3" });
+    await ctx.db.insert("messages", { author: "sarah", body: "hello4" });
+    await ctx.db.insert("messages", { author: "michal", body: "boing" });
+    await ctx.db.insert("messages", { author: "sarah", body: "hello5" });
+  });
+  const { continueCursor, isDone, page } = await t.query(api.pagination.list, {
+    author: "sarah",
+    paginationOptions: {
+      cursor: null,
+      numItems: 2,
+    },
+  });
+  expect(page).toMatchObject([
+    { author: "sarah", body: "hello1" },
+    { author: "sarah", body: "hello2" },
+  ]);
+  expect(isDone).toEqual(false);
+  await t.run(async (ctx) => {
+    await ctx.db.delete(page[1]._id);
+  });
+  const { isDone: isDone2, page: page2 } = await t.query(api.pagination.list, {
+    author: "sarah",
+    paginationOptions: {
+      cursor: continueCursor,
+      numItems: 4,
+    },
+  });
+  expect(page2).toMatchObject([
+    { author: "sarah", body: "hello3" },
+    { author: "sarah", body: "hello4" },
+    { author: "sarah", body: "hello5" },
+  ]);
+  expect(isDone2).toEqual(true);
+});


### PR DESCRIPTION
While doing pagination, if the document at the end of a page was deleted, it would cause pagination to break because we used that document's `_id` as the cursor. Thus, when the document was deleted, we couldn't find the beginning of the next page since the cursor's `_id` no longer existed.

I fixed this behavior by using the index keys of the last document in a page as the cursor. That way, if the document is deleted, we can still resume the paginated query at the correct place.

I added tests to confirm this behavior.