### PR TITLE
make t.run pass a ctx that works for actions as well

### DIFF
--- a/convex/actions.test.ts
+++ b/convex/actions.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "vitest";
 import { convexTest } from "../index";
 import { api, internal } from "./_generated/api";
 import schema from "./schema";
+import { actionCallingActionHandler } from "./actions";
 
 test("action calling query", async () => {
   const t = convexTest(schema);
@@ -25,6 +26,16 @@ test("action calling action", async () => {
     count: 2,
   });
   expect(result.called).toEqual(2);
+});
+
+test("calling action from t.run()", async () => {
+  const t = convexTest(schema);
+  await t.run(async (ctx) => {
+    const result = await actionCallingActionHandler(ctx, {
+      count: 2,
+    });
+    expect(result.called).toEqual(2);
+  });
 });
 
 test("action calling mutations concurrently", async () => {

--- a/convex/actions.ts
+++ b/convex/actions.ts
@@ -2,6 +2,7 @@ import { v } from "convex/values";
 import { api, internal } from "./_generated/api";
 import {
   action,
+  ActionCtx,
   internalAction,
   internalQuery,
   mutation,
@@ -51,17 +52,21 @@ export const actionCallingMutation = action({
 
 export const actionCallingAction = internalAction({
   args: { count: v.number() },
-  handler: async (ctx, { count }) => {
-    if (count > 0) {
-      const result: { called: number } = await ctx.runAction(
-        internal.actions.actionCallingAction,
-        { count: count - 1 },
-      );
-      return { called: result.called + 1 };
-    }
-    return { called: 0 };
-  },
+  handler: actionCallingActionHandler,
 });
+export async function actionCallingActionHandler(
+  ctx: ActionCtx,
+  { count }: { count: number },
+) {
+  if (count > 0) {
+    const result: { called: number } = await ctx.runAction(
+      internal.actions.actionCallingAction,
+      { count: count - 1 },
+    );
+    return { called: result.called + 1 };
+  }
+  return { called: 0 };
+}
 
 /// actions calling mutations concurrently
 


### PR DESCRIPTION
<!-- Describe your PR here. -->
Allow doing `t.run((ctx) => actionHelperFunction(ctx))` - before it wasn't clear how to construct a ctx to pass to helper functions. 
Can also help calling component thick clients, and basis for testing workflows


<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
