### PR TITLE
Update `convex` peer dependency version to ^1.25.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "vitest": "^1.4.0"
       },
       "peerDependencies": {
-        "convex": "^1.16.4"
+        "convex": "^1.25.4"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "author": "Sarah Shader & Michal Srb <srb@convex.dev>",
   "license": "Apache-2.0",
   "peerDependencies": {
-    "convex": "^1.16.4"
+    "convex": "^1.25.4"
   },
   "devDependencies": {
     "@edge-runtime/vm": "^3.2.0",


### PR DESCRIPTION
Since convex-test 0.0.39, we support the explicit table name syntax in `ctx.db` (e.g. `ctx.db.get("users", userId)`). Since its implementation depends on a change in convex-js that we added in `convex@1.25.4`, we should also update the peer dependency requirement for convex-test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency version for enhanced compatibility and ongoing support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->