### PR TITLE
support inline fns for t.query et. al.

### DIFF
--- a/convex/actions.test.ts
+++ b/convex/actions.test.ts
@@ -6,7 +6,7 @@ import { actionCallingActionHandler } from "./actions";
 
 test("action calling query", async () => {
   const t = convexTest(schema);
-  await t.run(async (ctx) => {
+  await t.mutation(async (ctx) => {
     await ctx.db.insert("messages", { body: "foo", author: "test" });
   });
   const result = await t.action(internal.actions.actionCallingQuery);
@@ -28,15 +28,12 @@ test("action calling action", async () => {
   expect(result.called).toEqual(2);
 });
 
-test.skip("calling action from t.run()", async () => {
+test("action calling action via handler helper", async () => {
   const t = convexTest(schema);
-  await t.run(async (ctx) => {
-    // @ts-expect-error -- ActionCtx support was added in 0.0.40, removed in 0.0.41, should be added back in the future.
-    const result = await actionCallingActionHandler(ctx, {
-      count: 2,
-    });
-    expect(result.called).toEqual(2);
+  const result = await t.action(async (ctx) => {
+    return await actionCallingActionHandler(ctx, { count: 2 });
   });
+  expect(result.called).toEqual(2);
 });
 
 test("action calling mutations concurrently", async () => {

--- a/convex/helpers.test.ts
+++ b/convex/helpers.test.ts
@@ -1,0 +1,130 @@
+import { expect, test } from "vitest";
+import { convexTest } from "../index";
+import schema from "./schema";
+import {
+  countMessages,
+  getMessageBodies,
+  getMessagesByAuthor,
+  insertMessage,
+  insertMessages,
+} from "./helpers";
+
+test("query helper: getMessagesByAuthor", async () => {
+  const t = convexTest(schema);
+  await t.mutation(async (ctx) => {
+    await ctx.db.insert("messages", { author: "alice", body: "hello" });
+    await ctx.db.insert("messages", { author: "bob", body: "world" });
+    await ctx.db.insert("messages", { author: "alice", body: "goodbye" });
+  });
+
+  const aliceMessages = await t.query(async (ctx) =>
+    getMessagesByAuthor(ctx, "alice"),
+  );
+  expect(aliceMessages).toHaveLength(2);
+  expect(aliceMessages).toMatchObject([
+    { author: "alice", body: "hello" },
+    { author: "alice", body: "goodbye" },
+  ]);
+
+  const bobMessages = await t.query(async (ctx) =>
+    getMessagesByAuthor(ctx, "bob"),
+  );
+  expect(bobMessages).toMatchObject([{ author: "bob", body: "world" }]);
+});
+
+test("query helper: countMessages", async () => {
+  const t = convexTest(schema);
+
+  const emptyCount = await t.query(async (ctx) => countMessages(ctx));
+  expect(emptyCount).toBe(0);
+
+  await t.mutation(async (ctx) => {
+    await ctx.db.insert("messages", { author: "alice", body: "one" });
+    await ctx.db.insert("messages", { author: "bob", body: "two" });
+    await ctx.db.insert("messages", { author: "charlie", body: "three" });
+  });
+
+  const count = await t.query(async (ctx) => countMessages(ctx));
+  expect(count).toBe(3);
+});
+
+test("query helper: getMessageBodies (helper calling helper)", async () => {
+  const t = convexTest(schema);
+  await t.mutation(async (ctx) => {
+    await ctx.db.insert("messages", { author: "alice", body: "first" });
+    await ctx.db.insert("messages", { author: "alice", body: "second" });
+    await ctx.db.insert("messages", { author: "bob", body: "other" });
+  });
+
+  const bodies = await t.query(async (ctx) => getMessageBodies(ctx, "alice"));
+  expect(bodies).toEqual(["first", "second"]);
+});
+
+test("mutation helper: insertMessage", async () => {
+  const t = convexTest(schema);
+
+  const id = await t.mutation(async (ctx) =>
+    insertMessage(ctx, "alice", "hello"),
+  );
+  expect(id).toBeDefined();
+
+  const messages = await t.query(async (ctx) =>
+    getMessagesByAuthor(ctx, "alice"),
+  );
+  expect(messages).toMatchObject([{ author: "alice", body: "hello" }]);
+});
+
+test("mutation helper: insertMessages", async () => {
+  const t = convexTest(schema);
+
+  const ids = await t.mutation(async (ctx) =>
+    insertMessages(ctx, [
+      { author: "alice", body: "one" },
+      { author: "alice", body: "two" },
+      { author: "bob", body: "three" },
+    ]),
+  );
+  expect(ids).toHaveLength(3);
+
+  const count = await t.query(async (ctx) => countMessages(ctx));
+  expect(count).toBe(3);
+
+  const aliceBodies = await t.query(async (ctx) =>
+    getMessageBodies(ctx, "alice"),
+  );
+  expect(aliceBodies).toEqual(["one", "two"]);
+});
+
+test("mixing helpers with inline logic", async () => {
+  const t = convexTest(schema);
+
+  await t.mutation(async (ctx) => {
+    await insertMessage(ctx, "alice", "hello");
+    // Mix helper with direct db access
+    await ctx.db.insert("messages", { author: "alice", body: "world" });
+  });
+
+  const result = await t.query(async (ctx) => {
+    const messages = await getMessagesByAuthor(ctx, "alice");
+    // Process results with inline logic
+    return messages.map((m) => m.body.toUpperCase());
+  });
+  expect(result).toEqual(["HELLO", "WORLD"]);
+});
+
+test("helpers with identity", async () => {
+  const t = convexTest(schema);
+  const authT = t.withIdentity({ name: "Test User" });
+
+  await authT.mutation(async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    await insertMessage(ctx, identity!.name!, "authenticated message");
+  });
+
+  const messages = await authT.query(async (ctx) =>
+    getMessagesByAuthor(ctx, "Test User"),
+  );
+  expect(messages).toMatchObject([
+    { author: "Test User", body: "authenticated message" },
+  ]);
+});

--- a/convex/helpers.ts
+++ b/convex/helpers.ts
@@ -1,0 +1,37 @@
+import { MutationCtx, QueryCtx } from "./_generated/server";
+
+export async function getMessagesByAuthor(ctx: QueryCtx, author: string) {
+  return await ctx.db
+    .query("messages")
+    .withIndex("author", (q) => q.eq("author", author))
+    .collect();
+}
+
+export async function countMessages(ctx: QueryCtx) {
+  const messages = await ctx.db.query("messages").collect();
+  return messages.length;
+}
+
+export async function getMessageBodies(ctx: QueryCtx, author: string) {
+  const messages = await getMessagesByAuthor(ctx, author);
+  return messages.map((m) => m.body);
+}
+
+export async function insertMessage(
+  ctx: MutationCtx,
+  author: string,
+  body: string,
+) {
+  return await ctx.db.insert("messages", { author, body });
+}
+
+export async function insertMessages(
+  ctx: MutationCtx,
+  messages: { author: string; body: string }[],
+) {
+  const ids = [];
+  for (const msg of messages) {
+    ids.push(await insertMessage(ctx, msg.author, msg.body));
+  }
+  return ids;
+}

--- a/convex/inlineFunctions.test.ts
+++ b/convex/inlineFunctions.test.ts
@@ -1,0 +1,171 @@
+import { expect, test } from "vitest";
+import { convexTest } from "../index";
+import { api } from "./_generated/api";
+import schema from "./schema";
+
+test("inline query", async () => {
+  const t = convexTest(schema);
+  await t.run(async (ctx) => {
+    await ctx.db.insert("messages", { author: "sarah", body: "hello1" });
+    await ctx.db.insert("messages", { author: "sarah", body: "hello2" });
+  });
+  const messages = await t.query(async (ctx) => {
+    return await ctx.db.query("messages").collect();
+  });
+  expect(messages).toMatchObject([
+    { author: "sarah", body: "hello1" },
+    { author: "sarah", body: "hello2" },
+  ]);
+});
+
+test("inline mutation insert", async () => {
+  const t = convexTest(schema);
+  const id = await t.mutation(async (ctx) => {
+    return await ctx.db.insert("messages", { author: "sarah", body: "hello" });
+  });
+  expect(id).toBeDefined();
+  const messages = await t.query(async (ctx) => {
+    return await ctx.db.query("messages").collect();
+  });
+  expect(messages).toMatchObject([{ author: "sarah", body: "hello" }]);
+});
+
+test("inline mutation patch", async () => {
+  const t = convexTest(schema);
+  const id = await t.mutation(async (ctx) => {
+    return await ctx.db.insert("messages", { author: "sarah", body: "hello" });
+  });
+  await t.mutation(async (ctx) => {
+    await ctx.db.patch(id, { body: "updated" });
+  });
+  const message = await t.query(async (ctx) => {
+    return await ctx.db.get(id);
+  });
+  expect(message).toMatchObject({ author: "sarah", body: "updated" });
+});
+
+test("inline mutation delete", async () => {
+  const t = convexTest(schema);
+  const id = await t.mutation(async (ctx) => {
+    return await ctx.db.insert("messages", { author: "sarah", body: "hello" });
+  });
+  await t.mutation(async (ctx) => {
+    await ctx.db.delete(id);
+  });
+  const message = await t.query(async (ctx) => {
+    return await ctx.db.get(id);
+  });
+  expect(message).toBeNull();
+});
+
+test("inline query is read-only (no db.insert)", async () => {
+  const t = convexTest(schema);
+  await expect(async () => {
+    await t.query(async (ctx) => {
+      // @ts-expect-error - queries should not have insert
+      await ctx.db.insert("messages", { author: "sarah", body: "hello" });
+    });
+  }).rejects.toThrow();
+});
+
+test("inline mutation transaction rollback", async () => {
+  const t = convexTest(schema);
+  await expect(async () => {
+    await t.mutation(async (ctx) => {
+      await ctx.db.insert("messages", { author: "sarah", body: "hello" });
+      throw new Error("rollback");
+    });
+  }).rejects.toThrowError("rollback");
+
+  const messages = await t.query(async (ctx) => {
+    return await ctx.db.query("messages").collect();
+  });
+  expect(messages).toMatchObject([]);
+});
+
+test("inline functions with identity", async () => {
+  const t = convexTest(schema);
+  const identity = await t
+    .withIdentity({ name: "Test User" })
+    .query(async (ctx) => {
+      return await ctx.auth.getUserIdentity();
+    });
+  expect(identity).toMatchObject({ name: "Test User" });
+});
+
+test("inline query returns value", async () => {
+  const t = convexTest(schema);
+  await t.run(async (ctx) => {
+    await ctx.db.insert("messages", { author: "sarah", body: "hello" });
+  });
+  const count = await t.query(async (ctx) => {
+    const messages = await ctx.db.query("messages").collect();
+    return messages.length + 41;
+  });
+  expect(count).toBe(42);
+});
+
+test("inline mutation returns inserted id", async () => {
+  const t = convexTest(schema);
+  const id = await t.mutation(async (ctx) => {
+    const insertedId = await ctx.db.insert("messages", {
+      author: "sarah",
+      body: "hello",
+    });
+    return insertedId;
+  });
+  expect(typeof id).toBe("string");
+  expect(id).toContain("messages");
+});
+
+test("inline action basic", async () => {
+  const t = convexTest(schema);
+  const result = await t.action(async () => {
+    return "hello from action";
+  });
+  expect(result).toBe("hello from action");
+});
+
+test("inline action with return value", async () => {
+  const t = convexTest(schema);
+  const result = await t.action(async () => {
+    return { count: 42, message: "success" };
+  });
+  expect(result).toEqual({ count: 42, message: "success" });
+});
+
+test("inline action calling function reference via ctx.runQuery", async () => {
+  const t = convexTest(schema);
+  await t.run(async (ctx) => {
+    await ctx.db.insert("messages", { author: "sarah", body: "hello" });
+  });
+  const result = await t.action(async (ctx) => {
+    const messages = await ctx.runQuery(api.queries.list);
+    return messages;
+  });
+  expect(result).toMatchObject([{ author: "sarah", body: "hello" }]);
+});
+
+test("inline action calling function reference via ctx.runMutation", async () => {
+  const t = convexTest(schema);
+  await t.action(async (ctx) => {
+    await ctx.runMutation(api.mutations.insert, {
+      author: "action",
+      body: "test",
+    });
+  });
+  const messages = await t.query(async (ctx) => {
+    return await ctx.db.query("messages").collect();
+  });
+  expect(messages).toMatchObject([{ author: "action", body: "test" }]);
+});
+
+test("inline action with identity", async () => {
+  const t = convexTest(schema);
+  const identity = await t
+    .withIdentity({ name: "Action User" })
+    .action(async (ctx) => {
+      return await ctx.auth.getUserIdentity();
+    });
+  expect(identity).toMatchObject({ name: "Action User" });
+});

--- a/index.ts
+++ b/index.ts
@@ -1941,13 +1941,19 @@ function withAuth(auth: AuthFake = new AuthFake()) {
     });
     getTransactionManager().beginAction(functionPath);
     const requestId = "" + Math.random();
-    const rawResult = await (
-      a as unknown as {
-        invokeAction: (requestId: string, args: string) => Promise<string>;
-      }
-    ).invokeAction(requestId, JSON.stringify(convexToJson([parseArgs(args)])));
-    getTransactionManager().finishAction();
-    return jsonToConvex(JSON.parse(rawResult)) as T;
+    try {
+      const rawResult = await (
+        a as unknown as {
+          invokeAction: (requestId: string, args: string) => Promise<string>;
+        }
+      ).invokeAction(
+        requestId,
+        JSON.stringify(convexToJson([parseArgs(args)])),
+      );
+      return jsonToConvex(JSON.parse(rawResult)) as T;
+    } finally {
+      getTransactionManager().finishAction();
+    }
   };
 
   const byTypeWithPath = {

--- a/index.ts
+++ b/index.ts
@@ -1191,7 +1191,7 @@ function asyncSyscallImpl() {
           args: udfArgsJson,
         } = args;
         const udfArgs = jsonToConvex(udfArgsJson);
-        const functionPath = await getFunctionPathFromAddress({
+        const functionPath = getFunctionPathFromAddress({
           name,
           reference,
           functionHandle,
@@ -1224,7 +1224,7 @@ function asyncSyscallImpl() {
       }
       case "1.0/createFunctionHandle": {
         const { name, reference, functionHandle } = args;
-        const functionPath = await getFunctionPathFromAddress({
+        const functionPath = getFunctionPathFromAddress({
           name,
           reference,
           functionHandle,
@@ -1246,7 +1246,7 @@ function asyncSyscallImpl() {
           args: fnArgs,
           ts: tsInSecs,
         } = args;
-        const functionPath = await getFunctionPathFromAddress({
+        const functionPath = getFunctionPathFromAddress({
           name,
           reference,
           functionHandle,
@@ -2231,12 +2231,12 @@ function parseFunctionHandle(handle: string) {
   return { componentPath, udfPath };
 }
 
-async function getFunctionPathFromAddress(
+function getFunctionPathFromAddress(
   functionAddress:
     | { name: string; reference: undefined; functionHandle: undefined }
     | { reference: string; name: undefined; functionHandle: undefined }
     | { functionHandle: string; name: undefined; reference: undefined },
-): Promise<FunctionPath> {
+): FunctionPath {
   if (functionAddress.functionHandle !== undefined) {
     return parseFunctionHandle(functionAddress.functionHandle);
   }
@@ -2276,7 +2276,7 @@ async function getFunctionPathFromReference(
   // { reference: "_reference/childComponent/aggregate/path/to/file/functionName" }
   // { functionHandle: "function://<id>/<path>" }
   const functionAddress = getFunctionAddress(functionReference);
-  return await getFunctionPathFromAddress(functionAddress);
+  return getFunctionPathFromAddress(functionAddress);
 }
 
 type RegisteredFunctions = {


### PR DESCRIPTION
# Support inline functions for test helpers

This PR adds support for inline functions in the test helpers, allowing developers to write:

```typescript
const messages = await t.query(async (ctx) => {
  return await ctx.db.query("messages").collect();
});
```

Instead of having to define a separate function. This works for `query`, `mutation`, and `action` test helpers.

Additionally:
- Made `getFunctionPathFromAddress` synchronous since it doesn't need to be async
- Added comprehensive tests for inline functions with various scenarios
- Fixed function references in action context to use `runQuery`, `runMutation`, and `runAction`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Test harness now supports inline execution for queries, mutations, and actions with typed context and new run helpers.
  * Added helper functions for messages (counting, querying by author, inserting single/batch messages).

* **Tests**
  * Added comprehensive tests for inline functions, helpers, identity-aware scenarios, CRUD flows, transaction rollback, and error propagation.
  * Updated test invocation patterns to align with the inline/run helper model.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/get-convex/convex-test/pull/64">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
