### PR TITLE
feat(validator): support unknownKeys strip mode in object validation

### DIFF
--- a/convex/argumentsValidation.test.ts
+++ b/convex/argumentsValidation.test.ts
@@ -3,8 +3,97 @@ import { convexTest } from "../index";
 import { api } from "./_generated/api";
 import schema from "./schema";
 import counterSchema from "./counter/component/schema";
+import * as argumentsValidationModule from "./argumentsValidation";
 
 const counterModules = import.meta.glob("./counter/component/**/*.ts");
+
+function patchExportArgs(
+  functionExport: {
+    exportArgs: () => string;
+  },
+  patch: (exported: any) => void,
+): () => void {
+  const hadOwnExportArgs = Object.prototype.hasOwnProperty.call(
+    functionExport,
+    "exportArgs",
+  );
+  const originalExportArgs = functionExport.exportArgs.bind(functionExport);
+  functionExport.exportArgs = () => {
+    const exported = JSON.parse(originalExportArgs());
+    patch(exported);
+    return JSON.stringify(exported);
+  };
+  return () => {
+    if (hadOwnExportArgs) {
+      functionExport.exportArgs = originalExportArgs;
+    } else {
+      delete (functionExport as any).exportArgs;
+    }
+  };
+}
+
+function forceStripUnknownKeys(functionExport: {
+  exportArgs: () => string;
+}): () => void {
+  return patchExportArgs(functionExport, (exported: any) => {
+    if (exported.type === "object") {
+      exported.unknownKeys = "strip";
+    }
+  });
+}
+
+function forceStripUnknownKeysOnUnionObjectField(
+  functionExport: {
+    exportArgs: () => string;
+  },
+  fieldName: string,
+  memberIndexes?: number[],
+): () => void {
+  return patchExportArgs(functionExport, (exported: any) => {
+    const union = exported?.value?.[fieldName]?.fieldType;
+    if (!union || union.type !== "union") {
+      throw new Error(`Expected a union field at args.${fieldName}`);
+    }
+    union.value.forEach((member: any, index: number) => {
+      if (member.type !== "object") {
+        return;
+      }
+      if (memberIndexes && !memberIndexes.includes(index)) {
+        return;
+      }
+      member.unknownKeys = "strip";
+    });
+  });
+}
+
+function forceStripUnknownKeysOnNestedUnionObjectField(
+  functionExport: {
+    exportArgs: () => string;
+  },
+  fieldName: string,
+  memberIndex: number,
+  nestedFieldName: string,
+): () => void {
+  return patchExportArgs(functionExport, (exported: any) => {
+    const union = exported?.value?.[fieldName]?.fieldType;
+    if (!union || union.type !== "union") {
+      throw new Error(`Expected a union field at args.${fieldName}`);
+    }
+    const member = union.value?.[memberIndex];
+    if (!member || member.type !== "object") {
+      throw new Error(
+        `Expected an object member at args.${fieldName}[${memberIndex}]`,
+      );
+    }
+    const nestedObject = member?.value?.[nestedFieldName]?.fieldType;
+    if (!nestedObject || nestedObject.type !== "object") {
+      throw new Error(
+        `Expected an object field at args.${fieldName}[${memberIndex}].${nestedFieldName}`,
+      );
+    }
+    nestedObject.unknownKeys = "strip";
+  });
+}
 
 test("query arguments validation", async () => {
   const t = convexTest(schema);
@@ -89,4 +178,144 @@ test("query with union arg", async () => {
       a: null as any,
     }),
   ).rejects.toThrowError(/Validator error/);
+});
+
+test("query object arg strip mode", async () => {
+  const t = convexTest(schema);
+  const restore = forceStripUnknownKeys(
+    argumentsValidationModule.queryWithStripObjectArg as any,
+  );
+  try {
+    expect(
+      await t.query(api.argumentsValidation.queryWithStripObjectArg, {
+        a: 42,
+        extra: "strip me",
+      } as any),
+    ).toEqual({ a: 42 });
+    await expect(
+      t.query(api.argumentsValidation.queryWithStripObjectArg, {
+        a: "bad" as any,
+      }),
+    ).rejects.toThrowError(/Validator error/);
+  } finally {
+    restore();
+  }
+});
+
+test("mutation object arg strip mode", async () => {
+  const t = convexTest(schema);
+  const restore = forceStripUnknownKeys(
+    argumentsValidationModule.mutationWithStripObjectArg as any,
+  );
+  try {
+    expect(
+      await t.mutation(api.argumentsValidation.mutationWithStripObjectArg, {
+        a: 42,
+        extra: "strip me",
+      } as any),
+    ).toEqual({ a: 42 });
+    await expect(
+      t.mutation(api.argumentsValidation.mutationWithStripObjectArg, {
+        a: "bad" as any,
+      }),
+    ).rejects.toThrowError(/Validator error/);
+  } finally {
+    restore();
+  }
+});
+
+test("action object arg strip mode", async () => {
+  const t = convexTest(schema);
+  const restore = forceStripUnknownKeys(
+    argumentsValidationModule.actionWithStripObjectArg as any,
+  );
+  try {
+    expect(
+      await t.action(api.argumentsValidation.actionWithStripObjectArg, {
+        a: 42,
+        extra: "strip me",
+      } as any),
+    ).toEqual({ a: 42 });
+    await expect(
+      t.action(api.argumentsValidation.actionWithStripObjectArg, {
+        a: "bad" as any,
+      }),
+    ).rejects.toThrowError(/Validator error/);
+  } finally {
+    restore();
+  }
+});
+
+test("union object arg prefers strict member over strip member", async () => {
+  const t = convexTest(schema);
+  const restore = forceStripUnknownKeysOnUnionObjectField(
+    argumentsValidationModule.queryWithUnionStripNarrowFirstArg as any,
+    "obj",
+    [0],
+  );
+  try {
+    expect(
+      await t.query(api.argumentsValidation.queryWithUnionStripNarrowFirstArg, {
+        obj: { a: 42, b: 7 },
+      } as any),
+    ).toEqual({ a: 42, b: 7 });
+  } finally {
+    restore();
+  }
+});
+
+test("union object arg uses declaration order among strip members", async () => {
+  const t = convexTest(schema);
+  const restore = forceStripUnknownKeysOnUnionObjectField(
+    argumentsValidationModule.queryWithUnionStripNarrowFirstArg as any,
+    "obj",
+  );
+  try {
+    expect(
+      await t.query(api.argumentsValidation.queryWithUnionStripNarrowFirstArg, {
+        obj: { a: 42, b: 7 },
+      } as any),
+    ).toEqual({ a: 42 });
+  } finally {
+    restore();
+  }
+});
+
+test("union object arg preserves more fields when strip members are reordered", async () => {
+  const t = convexTest(schema);
+  const restore = forceStripUnknownKeysOnUnionObjectField(
+    argumentsValidationModule.queryWithUnionStripWideFirstArg as any,
+    "obj",
+  );
+  try {
+    expect(
+      await t.query(api.argumentsValidation.queryWithUnionStripWideFirstArg, {
+        obj: { a: 42, b: 7 },
+      } as any),
+    ).toEqual({ a: 42, b: 7 });
+  } finally {
+    restore();
+  }
+});
+
+test("union object arg does not leak nested strip mutations across failed members", async () => {
+  const t = convexTest(schema);
+  const restore = forceStripUnknownKeysOnNestedUnionObjectField(
+    argumentsValidationModule.queryWithUnionNestedStripFailureArg as any,
+    "obj",
+    0,
+    "inner",
+  );
+  try {
+    expect(
+      await t.query(
+        api.argumentsValidation.queryWithUnionNestedStripFailureArg,
+        {
+          obj: { inner: { a: 42, extra: "keep me" } },
+        } as any,
+      ),
+    ).toEqual({ inner: { a: 42, extra: "keep me" } });
+  } finally {
+    restore();
+  }
 });

--- a/convex/argumentsValidation.test.ts
+++ b/convex/argumentsValidation.test.ts
@@ -32,6 +32,7 @@ function patchExportArgs(
   };
 }
 
+
 function forceStripUnknownKeys(functionExport: {
   exportArgs: () => string;
 }): () => void {
@@ -317,5 +318,26 @@ test("union object arg does not leak nested strip mutations across failed member
     ).toEqual({ inner: { a: 42, extra: "keep me" } });
   } finally {
     restore();
+  }
+});
+
+test("returns strip mode strips extra fields from output", async () => {
+  const t = convexTest(schema);
+  const func = argumentsValidationModule.queryWithStripReturn as any;
+  const originalExportReturns = func.exportReturns.bind(func);
+  func.exportReturns = () => {
+    const exported = JSON.parse(originalExportReturns());
+    exported.unknownKeys = "strip";
+    return JSON.stringify(exported);
+  };
+  try {
+    const result = await t.query(
+      api.argumentsValidation.queryWithStripReturn,
+      {},
+    );
+    expect(result).toEqual({ a: 1 });
+    expect((result as any).b).toBeUndefined();
+  } finally {
+    func.exportReturns = originalExportReturns;
   }
 });

--- a/convex/argumentsValidation.ts
+++ b/convex/argumentsValidation.ts
@@ -65,3 +65,65 @@ export const queryWithUnionArg = query({
     return "ok";
   },
 });
+
+export const queryWithStripObjectArg = query({
+  args: v.object({ a: v.number() }),
+  handler: (_, args) => {
+    return args;
+  },
+});
+
+export const mutationWithStripObjectArg = mutation({
+  args: v.object({ a: v.number() }),
+  handler: (_, args) => {
+    return args;
+  },
+});
+
+export const actionWithStripObjectArg = action({
+  args: v.object({ a: v.number() }),
+  handler: (_, args) => {
+    return args;
+  },
+});
+
+export const queryWithUnionStripNarrowFirstArg = query({
+  args: {
+    obj: v.union(
+      v.object({ a: v.number() }),
+      v.object({ a: v.number(), b: v.number() }),
+    ),
+  },
+  handler: (_, args) => {
+    return args.obj;
+  },
+});
+
+export const queryWithUnionStripWideFirstArg = query({
+  args: {
+    obj: v.union(
+      v.object({ a: v.number(), b: v.number() }),
+      v.object({ a: v.number() }),
+    ),
+  },
+  handler: (_, args) => {
+    return args.obj;
+  },
+});
+
+export const queryWithUnionNestedStripFailureArg = query({
+  args: {
+    obj: v.union(
+      v.object({
+        inner: v.object({ a: v.number() }),
+        must: v.string(),
+      }),
+      v.object({
+        inner: v.object({ a: v.number(), extra: v.string() }),
+      }),
+    ),
+  },
+  handler: (_, args) => {
+    return args.obj;
+  },
+});

--- a/convex/argumentsValidation.ts
+++ b/convex/argumentsValidation.ts
@@ -127,3 +127,11 @@ export const queryWithUnionNestedStripFailureArg = query({
     return args.obj;
   },
 });
+
+export const queryWithStripReturn = query({
+  args: {},
+  returns: v.object({ a: v.number() }),
+  handler: () => {
+    return { a: 1, b: 2 } as any;
+  },
+});

--- a/convex/schemaValidation.test.ts
+++ b/convex/schemaValidation.test.ts
@@ -4,6 +4,25 @@ import schema from "./schema";
 import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
 
+function schemaWithStripUnknownKeys() {
+  const stripSchema = defineSchema({
+    messages: defineTable({ author: v.string() }),
+  });
+  const table = stripSchema.tables.messages as any;
+  const originalExport = table.export.bind(table);
+  table.export = () => {
+    const exported = originalExport();
+    return {
+      ...exported,
+      documentType: {
+        ...exported.documentType,
+        unknownKeys: "strip",
+      },
+    };
+  };
+  return stripSchema;
+}
+
 test("extra fields", async () => {
   const t = convexTest(schema);
   await expect(
@@ -108,4 +127,59 @@ test("schema validation off", async () => {
       extraField: true,
     } as any);
   });
+});
+
+test("extra fields are stripped on insert in strip mode", async () => {
+  const t = convexTest(schemaWithStripUnknownKeys());
+  const doc = await t.run(async (ctx) => {
+    const id = await ctx.db.insert("messages", {
+      author: "sarah",
+      extraField: true,
+    } as any);
+    return await ctx.db.get(id);
+  });
+  expect(doc).not.toBeNull();
+  expect(doc!.author).toEqual("sarah");
+  expect((doc as any).extraField).toBeUndefined();
+});
+
+test("extra fields are stripped on patch in strip mode", async () => {
+  const t = convexTest(schemaWithStripUnknownKeys());
+  const doc = await t.run(async (ctx) => {
+    const id = await ctx.db.insert("messages", {
+      author: "sarah",
+    });
+    await ctx.db.patch(id, { extraField: true } as any);
+    return await ctx.db.get(id);
+  });
+  expect(doc).not.toBeNull();
+  expect(doc!.author).toEqual("sarah");
+  expect((doc as any).extraField).toBeUndefined();
+});
+
+test("extra fields are stripped on replace in strip mode", async () => {
+  const t = convexTest(schemaWithStripUnknownKeys());
+  const doc = await t.run(async (ctx) => {
+    const id = await ctx.db.insert("messages", {
+      author: "sarah",
+    });
+    await ctx.db.replace(id, { author: "tom", extraField: true } as any);
+    return await ctx.db.get(id);
+  });
+  expect(doc).not.toBeNull();
+  expect(doc!.author).toEqual("tom");
+  expect((doc as any).extraField).toBeUndefined();
+});
+
+test("strip mode still validates field types", async () => {
+  const t = convexTest(schemaWithStripUnknownKeys());
+  await expect(
+    async () =>
+      await t.run(async (ctx) => {
+        await ctx.db.insert("messages", {
+          author: 3,
+          extraField: true,
+        } as any);
+      }),
+  ).rejects.toThrowError("Validator error");
 });

--- a/index.ts
+++ b/index.ts
@@ -1173,8 +1173,52 @@ type ValidatorJSON =
     }
   | { type: "id"; tableName: string }
   | { type: "array"; value: ValidatorJSON }
-  | { type: "object"; value: Record<string, ObjectFieldType> }
+  | {
+      type: "object";
+      value: Record<string, ObjectFieldType>;
+      unknownKeys?: "strict" | "strip";
+    }
   | { type: "union"; value: ValidatorJSON[] };
+
+function hasStripObjectValidator(validator: ValidatorJSON): boolean {
+  switch (validator.type) {
+    case "object": {
+      if (validator.unknownKeys === "strip") {
+        return true;
+      }
+      return Object.values(validator.value).some(({ fieldType }) =>
+        hasStripObjectValidator(fieldType),
+      );
+    }
+    case "array": {
+      return hasStripObjectValidator(validator.value);
+    }
+    case "union": {
+      return validator.value.some(hasStripObjectValidator);
+    }
+    default: {
+      return false;
+    }
+  }
+}
+
+function copyValidatedValueIntoTarget(target: any, source: any) {
+  if (Array.isArray(target) && Array.isArray(source)) {
+    target.length = 0;
+    target.push(...source);
+    return;
+  }
+  if (isSimpleObject(target) && isSimpleObject(source)) {
+    for (const key of Object.keys(target)) {
+      if (!(key in source)) {
+        delete target[key];
+      }
+    }
+    for (const [key, sourceValue] of Object.entries(source)) {
+      target[key] = sourceValue;
+    }
+  }
+}
 
 function validateValidator(validator: ValidatorJSON, value: any) {
   switch (validator.type) {
@@ -1262,22 +1306,49 @@ function validateValidator(validator: ValidatorJSON, value: any) {
       return;
     }
     case "union": {
-      let isValid = false;
-      for (const v of validator.value) {
+      const tryValidate = (member: ValidatorJSON): boolean => {
+        const shouldIsolateMutation =
+          hasStripObjectValidator(member) &&
+          (isSimpleObject(value) || Array.isArray(value));
+        const candidateValue = shouldIsolateMutation
+          ? structuredClone(value)
+          : value;
         try {
-          validateValidator(v, value);
-          isValid = true;
-          break;
+          validateValidator(member, candidateValue);
+          if (shouldIsolateMutation) {
+            copyValidatedValueIntoTarget(value, candidateValue);
+          }
+          return true;
         } catch {
-          // Ignore
+          return false;
+        }
+      };
+
+      for (const member of validator.value) {
+        const isStripObject =
+          member.type === "object" && member.unknownKeys === "strip";
+        if (isStripObject) {
+          continue;
+        }
+        if (tryValidate(member)) {
+          return;
         }
       }
-      if (!isValid) {
-        throw new Error(
-          `Validator error: Expected one of ${validator.value.map((v) => v.type).join(", ")}, got \`${JSON.stringify(convexToJson(value))}\``,
-        );
+
+      for (const member of validator.value) {
+        const isStripObject =
+          member.type === "object" && member.unknownKeys === "strip";
+        if (!isStripObject) {
+          continue;
+        }
+        if (tryValidate(member)) {
+          return;
+        }
       }
-      return;
+
+      throw new Error(
+        `Validator error: Expected one of ${validator.value.map((v) => v.type).join(", ")}, got \`${JSON.stringify(convexToJson(value))}\``,
+      );
     }
     case "object": {
       if (typeof value !== "object") {
@@ -1303,12 +1374,22 @@ function validateValidator(validator: ValidatorJSON, value: any) {
           validateValidator(fieldType, value[k]);
         }
       }
+      const keysToStrip: string[] = [];
       for (const k of Object.keys(value)) {
         if (validator.value[k] === undefined) {
-          throw new Error(
-            `Validator error: Unexpected field \`${k}\` in object`,
-          );
+          if (validator.unknownKeys === "strip") {
+            keysToStrip.push(k);
+          } else {
+            throw new Error(
+              `Validator error: Unexpected field \`${k}\` in object`,
+            );
+          }
         }
+      }
+      // Defer deletions until after all validation passes, so that
+      // union variants that try-and-fail don't corrupt the shared value.
+      for (const k of keysToStrip) {
+        delete value[k];
       }
       return;
     }


### PR DESCRIPTION
## Summary

- Extends `validateValidator` to support `unknownKeys: "strip"` on object validators.
- Uses strict-first union matching for parity with backend/helpers updates:
  - First matching non-strip member
  - Otherwise first matching strip object member
- Keeps strip-mode object behavior: unknown fields are removed while type/required-field checks still apply.

## Changes

**Production (`index.ts`)**
- Added `unknownKeys?: "strict" | "strip"` to `ValidatorJSON` object validators.
- Updated object validation to defer deletions until validation succeeds (avoids union branch mutation side effects).
- Updated union validation to two passes (strict-first, then strip objects) for deterministic matching.

**Tests**
- `convex/argumentsValidation.ts`
  - Added union-object fixtures with different member orderings.
- `convex/argumentsValidation.test.ts`
  - Added union precedence tests:
    - strict member preferred over strip member
    - declaration order among strip members
    - reordered strip members preserve more fields
  - Kept existing strip-mode argument tests for query/mutation/action.
- `convex/schemaValidation.test.ts`
  - Existing strip-mode insert/patch/replace/type tests retained.

## Context

This supports the `v.object({ ... }, { unknownKeys: "strip" })` feature from [get-convex/convex-backend#348](https://github.com/get-convex/convex-backend/pull/348), aligned with corresponding helpers changes.

Note: tests monkey-patch serialized validator JSON to include `unknownKeys: "strip"` because the currently published `convex` package does not emit this property yet.