### PR TITLE
add pagination with indexes and test coverage repro

### DIFF
--- a/convex/pagination.test.ts
+++ b/convex/pagination.test.ts
@@ -192,3 +192,157 @@ test("paginate with endCursor", async () => {
   // Should get the same docs as result2
   expect(result3.page.length).toEqual(result2.page.length);
 });
+test("paginate with deletes", async () => {
+  const t = convexTest(schema);
+  await t.run(async (ctx) => {
+    await ctx.db.insert("messages", { author: "sarah", body: "hello1" });
+    await ctx.db.insert("messages", { author: "michal", body: "boo" });
+    await ctx.db.insert("messages", { author: "sarah", body: "hello2" });
+    await ctx.db.insert("messages", { author: "sarah", body: "hello3" });
+    await ctx.db.insert("messages", { author: "sarah", body: "hello4" });
+    await ctx.db.insert("messages", { author: "michal", body: "boing" });
+    await ctx.db.insert("messages", { author: "sarah", body: "hello5" });
+  });
+  const { continueCursor, isDone, page } = await t.query(api.pagination.list, {
+    author: "sarah",
+    paginationOptions: {
+      cursor: null,
+      numItems: 2,
+    },
+  });
+  expect(page).toMatchObject([
+    { author: "sarah", body: "hello1" },
+    { author: "sarah", body: "hello2" },
+  ]);
+  expect(isDone).toEqual(false);
+  await t.run(async (ctx) => {
+    await ctx.db.delete(page[1]._id);
+  });
+  const { isDone: isDone2, page: page2 } = await t.query(api.pagination.list, {
+    author: "sarah",
+    paginationOptions: {
+      cursor: continueCursor,
+      numItems: 4,
+    },
+  });
+  expect(page2).toMatchObject([
+    { author: "sarah", body: "hello3" },
+    { author: "sarah", body: "hello4" },
+    { author: "sarah", body: "hello5" },
+  ]);
+  expect(isDone2).toEqual(true);
+});
+
+test("paginate with deletes and indexes", async () => {
+  const t = convexTest(schema);
+  await t.run(async (ctx) => {
+    await ctx.db.insert("messages", { author: "sarah", body: "hello1" });
+    await ctx.db.insert("messages", { author: "jordan", body: "hello1" });
+    await ctx.db.insert("messages", { author: "jordan", body: "hello2" });
+    await ctx.db.insert("messages", { author: "jordan", body: "hello3" });
+    await ctx.db.insert("messages", { author: "jordan", body: "hello4" });
+  });
+  const { continueCursor, isDone, page } = await t.query(
+    api.pagination.listWithIndex,
+    {
+      author: "jordan",
+      paginationOptions: {
+        cursor: null,
+        numItems: 1,
+      },
+    },
+  );
+  expect(page).toMatchObject([{ author: "jordan", body: "hello1" }]);
+  expect(isDone).toEqual(false);
+  await t.run(async (ctx) => {
+    await ctx.db.delete(page[0]._id);
+  });
+  const {
+    isDone: isDone2,
+    page: page2,
+    continueCursor: continueCursor2,
+  } = await t.query(api.pagination.listWithIndex, {
+    author: "jordan",
+    paginationOptions: {
+      cursor: continueCursor,
+      numItems: 2,
+    },
+  });
+  expect(page2).toMatchObject([
+    { author: "jordan", body: "hello2" },
+    { author: "jordan", body: "hello3" },
+  ]);
+  expect(isDone2).toEqual(false);
+  await t.run(async (ctx) => {
+    await ctx.db.delete(page2[1]._id);
+  });
+  const { isDone: isDone3, page: page3 } = await t.query(
+    api.pagination.listWithIndex,
+    {
+      author: "jordan",
+      paginationOptions: {
+        cursor: continueCursor2,
+        numItems: 1,
+      },
+    },
+  );
+  expect(page3).toMatchObject([{ author: "jordan", body: "hello4" }]);
+  expect(isDone3).toEqual(true);
+});
+
+test("paginate with deletes and composite index", async () => {
+  const t = convexTest(schema);
+  await t.run(async (ctx) => {
+    await ctx.db.insert("messages", { author: "sarah", body: "hello1" });
+    await ctx.db.insert("messages", { author: "jordan", body: "hello2" });
+    await ctx.db.insert("messages", { author: "jordan", body: "hello4" });
+    await ctx.db.insert("messages", { author: "jordan", body: "hello3" });
+    await ctx.db.insert("messages", { author: "jordan", body: "hello1" });
+  });
+  const { continueCursor, isDone, page } = await t.query(
+    api.pagination.listWithCompositeIndex,
+    {
+      author: "jordan",
+      paginationOptions: {
+        cursor: null,
+        numItems: 1,
+      },
+    },
+  );
+  expect(page).toMatchObject([{ author: "jordan", body: "hello1" }]);
+  expect(isDone).toEqual(false);
+  await t.run(async (ctx) => {
+    await ctx.db.delete(page[0]._id);
+  });
+  const {
+    isDone: isDone2,
+    page: page2,
+    continueCursor: continueCursor2,
+  } = await t.query(api.pagination.listWithCompositeIndex, {
+    author: "jordan",
+    paginationOptions: {
+      cursor: continueCursor,
+      numItems: 2,
+    },
+  });
+  expect(page2).toMatchObject([
+    { author: "jordan", body: "hello2" },
+    { author: "jordan", body: "hello3" },
+  ]);
+  expect(isDone2).toEqual(false);
+  await t.run(async (ctx) => {
+    await ctx.db.delete(page2[1]._id);
+  });
+  const { isDone: isDone3, page: page3 } = await t.query(
+    api.pagination.listWithCompositeIndex,
+    {
+      author: "jordan",
+      paginationOptions: {
+        cursor: continueCursor2,
+        numItems: 1,
+      },
+    },
+  );
+  expect(page3).toMatchObject([{ author: "jordan", body: "hello4" }]);
+  expect(isDone3).toEqual(true);
+});

--- a/convex/pagination.test.ts
+++ b/convex/pagination.test.ts
@@ -192,6 +192,56 @@ test("paginate with endCursor", async () => {
   // Should get the same docs as result2
   expect(result3.page.length).toEqual(result2.page.length);
 });
+test("paginate with index on optional field with undefined values", async () => {
+  const t = convexTest(schema);
+  await t.run(async (ctx) => {
+    await ctx.db.insert("messages", {
+      author: "sarah",
+      body: "hello1",
+      score: 10,
+    });
+    await ctx.db.insert("messages", { author: "sarah", body: "hello2" }); // score undefined
+    await ctx.db.insert("messages", {
+      author: "sarah",
+      body: "hello3",
+      score: 5,
+    });
+    await ctx.db.insert("messages", { author: "sarah", body: "hello4" }); // score undefined
+  });
+  const { continueCursor, isDone, page } = await t.query(
+    api.pagination.listWithOptionalFieldIndex,
+    {
+      author: "sarah",
+      paginationOptions: {
+        cursor: null,
+        numItems: 2,
+      },
+    },
+  );
+  // undefined scores should sort before defined scores
+  expect(page).toMatchObject([
+    { author: "sarah", body: "hello2" }, // score undefined
+    { author: "sarah", body: "hello4" }, // score undefined
+  ]);
+  expect(isDone).toEqual(false);
+  const { isDone: isDone2, page: page2 } = await t.query(
+    api.pagination.listWithOptionalFieldIndex,
+    {
+      author: "sarah",
+      paginationOptions: {
+        cursor: continueCursor,
+        numItems: 4,
+      },
+    },
+  );
+  // then defined scores in ascending order
+  expect(page2).toMatchObject([
+    { author: "sarah", body: "hello3", score: 5 },
+    { author: "sarah", body: "hello1", score: 10 },
+  ]);
+  expect(isDone2).toEqual(true);
+});
+
 test("paginate with deletes", async () => {
   const t = convexTest(schema);
   await t.run(async (ctx) => {

--- a/convex/pagination.ts
+++ b/convex/pagination.ts
@@ -25,3 +25,29 @@ export const listAll = query({
     return await ctx.db.query("messages").paginate(args.paginationOptions);
   },
 });
+
+export const listWithIndex = query({
+  args: {
+    author: v.string(),
+    paginationOptions: paginationOptsValidator,
+  },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("messages")
+      .withIndex("author", (q) => q.eq("author", args.author))
+      .paginate(args.paginationOptions);
+  },
+});
+
+export const listWithCompositeIndex = query({
+  args: {
+    author: v.string(),
+    paginationOptions: paginationOptsValidator,
+  },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("messages")
+      .withIndex("author_body", (q) => q.eq("author", args.author))
+      .paginate(args.paginationOptions);
+  },
+});

--- a/convex/pagination.ts
+++ b/convex/pagination.ts
@@ -39,6 +39,19 @@ export const listWithIndex = query({
   },
 });
 
+export const listWithOptionalFieldIndex = query({
+  args: {
+    author: v.string(),
+    paginationOptions: paginationOptsValidator,
+  },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("messages")
+      .withIndex("author_score", (q) => q.eq("author", args.author))
+      .paginate(args.paginationOptions);
+  },
+});
+
 export const listWithCompositeIndex = query({
   args: {
     author: v.string(),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -9,6 +9,7 @@ export default defineSchema({
     score: v.optional(v.number()),
   })
     .index("author", ["author"])
+    .index("author_body", ["author", "body"])
     .searchIndex("body", {
       searchField: "body",
       filterFields: ["author"],

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -10,6 +10,7 @@ export default defineSchema({
   })
     .index("author", ["author"])
     .index("author_body", ["author", "body"])
+    .index("author_score", ["author", "score"])
     .searchIndex("body", {
       searchField: "body",
       filterFields: ["author"],

--- a/index.ts
+++ b/index.ts
@@ -504,45 +504,28 @@ class DatabaseFake {
           } else {
             continue;
           }
-        } else if (cursor !== null) {
-          // Legacy fallback: plain _id cursor
-          if ((doc._id as string) === cursor) {
-            isInPage = true;
-          }
-          continue;
         }
       }
 
       // endCursor: stop when we reach or pass this position (inclusive boundary)
-      if (hasEndBoundary) {
-        if (endCursorKeys) {
-          const cmp = this._docIsAfterCursor(
-            doc,
-            endCursorKeys,
-            cursorFields,
-            order,
-          );
-          if (cmp >= 0) {
-            // At or past end cursor — include this doc if exactly at cursor, then stop
-            if (cmp === 0) {
-              rowsRead += 1;
-              bytesRead += getDocumentSize(doc);
-              readDocCursors.push(this._encodeCursor(doc, cursorFields));
-              if (filterFn(doc)) {
-                page.push(doc);
-              }
-              continueCursor = this._encodeCursor(doc, cursorFields);
+      if (hasEndBoundary && endCursorKeys) {
+        const cmp = this._docIsAfterCursor(
+          doc,
+          endCursorKeys,
+          cursorFields,
+          order,
+        );
+        if (cmp >= 0) {
+          // At or past end cursor — include this doc if exactly at cursor, then stop
+          if (cmp === 0) {
+            rowsRead += 1;
+            bytesRead += getDocumentSize(doc);
+            readDocCursors.push(this._encodeCursor(doc, cursorFields));
+            if (filterFn(doc)) {
+              page.push(doc);
             }
-            break;
+            continueCursor = this._encodeCursor(doc, cursorFields);
           }
-        } else if ((doc._id as string) === endCursor) {
-          rowsRead += 1;
-          bytesRead += getDocumentSize(doc);
-          readDocCursors.push(this._encodeCursor(doc, cursorFields));
-          if (filterFn(doc)) {
-            page.push(doc);
-          }
-          continueCursor = this._encodeCursor(doc, cursorFields);
           break;
         }
       }

--- a/index.ts
+++ b/index.ts
@@ -421,10 +421,7 @@ class DatabaseFake {
     }
   }
 
-  private _encodeCursor(
-    doc: GenericDocument,
-    fieldPaths: string[],
-  ): string {
+  private _encodeCursor(doc: GenericDocument, fieldPaths: string[]): string {
     const keys = fieldPaths.map((fp) => evaluateFieldPath(fp, doc));
     return JSON.stringify(keys);
   }
@@ -460,7 +457,6 @@ class DatabaseFake {
     maximumRowsRead?: number | null;
     maximumBytesRead?: number | null;
   }) {
-
     const { sortedDocs, filterFn, fieldPathsToSortBy, order } =
       this._resolveQuerySource(query);
 
@@ -501,7 +497,9 @@ class DatabaseFake {
       if (!isInPage) {
         if (cursorKeys) {
           // Sort-key-based cursor: skip docs at or before cursor position
-          if (this._docIsAfterCursor(doc, cursorKeys, cursorFields, order) > 0) {
+          if (
+            this._docIsAfterCursor(doc, cursorKeys, cursorFields, order) > 0
+          ) {
             isInPage = true;
           } else {
             continue;
@@ -518,7 +516,12 @@ class DatabaseFake {
       // endCursor: stop when we reach or pass this position (inclusive boundary)
       if (hasEndBoundary) {
         if (endCursorKeys) {
-          const cmp = this._docIsAfterCursor(doc, endCursorKeys, cursorFields, order);
+          const cmp = this._docIsAfterCursor(
+            doc,
+            endCursorKeys,
+            cursorFields,
+            order,
+          );
           if (cmp >= 0) {
             // At or past end cursor — include this doc if exactly at cursor, then stop
             if (cmp === 0) {

--- a/index.ts
+++ b/index.ts
@@ -421,6 +421,30 @@ class DatabaseFake {
     }
   }
 
+  private _encodeCursor(
+    doc: GenericDocument,
+    fieldPaths: string[],
+  ): string {
+    const keys = fieldPaths.map((fp) => evaluateFieldPath(fp, doc));
+    return JSON.stringify(keys);
+  }
+
+  private _docIsAfterCursor(
+    doc: GenericDocument,
+    cursorKeys: any[],
+    fieldPaths: string[],
+    order: "asc" | "desc",
+  ): number {
+    const orderMultiplier = order === "asc" ? 1 : -1;
+    for (let i = 0; i < fieldPaths.length; i++) {
+      const docVal = evaluateFieldPath(fieldPaths[i], doc);
+      const cursorVal = cursorKeys[i];
+      const cmp = compareValues(docVal, cursorVal);
+      if (cmp !== 0) return cmp * orderMultiplier;
+    }
+    return 0;
+  }
+
   paginate({
     query,
     cursor,
@@ -436,9 +460,31 @@ class DatabaseFake {
     maximumRowsRead?: number | null;
     maximumBytesRead?: number | null;
   }) {
-    const { sortedDocs, filterFn } = this._resolveQuerySource(query);
+
+    const { sortedDocs, filterFn, fieldPathsToSortBy, order } =
+      this._resolveQuerySource(query);
+
+    // Always include _id in sort key fields for uniqueness
+    const cursorFields = fieldPathsToSortBy.includes("_id")
+      ? fieldPathsToSortBy
+      : [...fieldPathsToSortBy, "_id"];
+
+    const parseCursor = (c: string | null | undefined) => {
+      if (!c || c === "_end_cursor") return null;
+      try {
+        return JSON.parse(c) as any[];
+      } catch {
+        return null;
+      }
+    };
+
+    const cursorKeys = parseCursor(cursor);
+    // _end_cursor as endCursor means "to the end of the range" — no boundary
+    const hasEndBoundary = !!endCursor && endCursor !== "_end_cursor";
+    const endCursorKeys = hasEndBoundary ? parseCursor(endCursor) : null;
 
     const page: GenericDocument[] = [];
+    // null cursor = start of range
     let isInPage = cursor === null;
     let isDone = false;
     let continueCursor: string | null = null;
@@ -446,34 +492,61 @@ class DatabaseFake {
     let pageStatus: "SplitRecommended" | "SplitRequired" | null = null;
     let rowsRead = 0;
     let bytesRead = 0;
-    const readDocIds: string[] = [];
+    const readDocCursors: string[] = [];
 
-    for (const doc of sortedDocs) {
+    for (let i = 0; i < sortedDocs.length; i++) {
+      const doc = sortedDocs[i];
+      const isLastDoc = i === sortedDocs.length - 1;
+
       if (!isInPage) {
-        if ((doc._id as string) === cursor) {
-          isInPage = true;
+        if (cursorKeys) {
+          // Sort-key-based cursor: skip docs at or before cursor position
+          if (this._docIsAfterCursor(doc, cursorKeys, cursorFields, order) > 0) {
+            isInPage = true;
+          } else {
+            continue;
+          }
+        } else if (cursor !== null) {
+          // Legacy fallback: plain _id cursor
+          if ((doc._id as string) === cursor) {
+            isInPage = true;
+          }
+          continue;
         }
-        continue;
       }
 
-      // endCursor: stop when we reach this document (inclusive boundary)
-      if (endCursor && endCursor !== "_end_cursor") {
-        if ((doc._id as string) === endCursor) {
-          // Include this doc if it passes filter, then stop
+      // endCursor: stop when we reach or pass this position (inclusive boundary)
+      if (hasEndBoundary) {
+        if (endCursorKeys) {
+          const cmp = this._docIsAfterCursor(doc, endCursorKeys, cursorFields, order);
+          if (cmp >= 0) {
+            // At or past end cursor — include this doc if exactly at cursor, then stop
+            if (cmp === 0) {
+              rowsRead += 1;
+              bytesRead += getDocumentSize(doc);
+              readDocCursors.push(this._encodeCursor(doc, cursorFields));
+              if (filterFn(doc)) {
+                page.push(doc);
+              }
+              continueCursor = this._encodeCursor(doc, cursorFields);
+            }
+            break;
+          }
+        } else if ((doc._id as string) === endCursor) {
           rowsRead += 1;
           bytesRead += getDocumentSize(doc);
-          readDocIds.push(doc._id as string);
+          readDocCursors.push(this._encodeCursor(doc, cursorFields));
           if (filterFn(doc)) {
             page.push(doc);
           }
-          continueCursor = doc._id as string;
+          continueCursor = this._encodeCursor(doc, cursorFields);
           break;
         }
       }
 
       rowsRead += 1;
       bytesRead += getDocumentSize(doc);
-      readDocIds.push(doc._id as string);
+      readDocCursors.push(this._encodeCursor(doc, cursorFields));
 
       // Check bandwidth limits
       let hitLimit = false;
@@ -490,12 +563,16 @@ class DatabaseFake {
 
       if (hitLimit) {
         pageStatus = "SplitRequired";
-        continueCursor = doc._id as string;
+        continueCursor = this._encodeCursor(doc, cursorFields);
         break;
       }
 
       if (!endCursor && page.length >= pageSize) {
-        continueCursor = doc._id as string;
+        if (isLastDoc) {
+          // No more docs — don't set continueCursor so isDone becomes true
+        } else {
+          continueCursor = this._encodeCursor(doc, cursorFields);
+        }
         break;
       }
     }
@@ -506,18 +583,18 @@ class DatabaseFake {
     }
 
     // Compute splitCursor at midpoint when limits are hit
-    if (pageStatus === "SplitRequired" && readDocIds.length >= 2) {
-      const midIdx = Math.floor((readDocIds.length - 1) / 2);
-      splitCursor = readDocIds[midIdx];
+    if (pageStatus === "SplitRequired" && readDocCursors.length >= 2) {
+      const midIdx = Math.floor((readDocCursors.length - 1) / 2);
+      splitCursor = readDocCursors[midIdx];
     } else if (
       pageStatus === null &&
       rowsRead > pageSize + 1 &&
-      readDocIds.length >= 2
+      readDocCursors.length >= 2
     ) {
       // Recommend split when we had to scan significantly more rows than pageSize
       pageStatus = "SplitRecommended";
-      const midIdx = Math.floor((readDocIds.length - 1) / 2);
-      splitCursor = readDocIds[midIdx];
+      const midIdx = Math.floor((readDocCursors.length - 1) / 2);
+      splitCursor = readDocCursors[midIdx];
     }
 
     return {
@@ -559,6 +636,8 @@ class DatabaseFake {
     sortedDocs: GenericDocument[];
     filterFn: (doc: GenericDocument) => boolean;
     limit: number | null;
+    fieldPathsToSortBy: string[];
+    order: "asc" | "desc";
   } {
     const source = query.source;
     const results: GenericDocument[] = [];
@@ -655,6 +734,8 @@ class DatabaseFake {
       sortedDocs: results,
       filterFn,
       limit: limit?.limit ?? null,
+      fieldPathsToSortBy,
+      order,
     };
   }
 

--- a/index.ts
+++ b/index.ts
@@ -423,7 +423,14 @@ class DatabaseFake {
 
   private _encodeCursor(doc: GenericDocument, fieldPaths: string[]): string {
     const keys = fieldPaths.map((fp) => evaluateFieldPath(fp, doc));
-    return JSON.stringify(keys);
+    // null sentinel in the array = undefined field value.
+    // Everything else is JSON.stringify(convexToJson(k)) producing a string,
+    // so null vs string is unambiguous on decode.
+    return JSON.stringify(
+      keys.map((k) =>
+        k === undefined ? null : JSON.stringify(convexToJson(k)),
+      ),
+    );
   }
 
   private _docIsAfterCursor(
@@ -466,15 +473,14 @@ class DatabaseFake {
       : [...fieldPathsToSortBy, "_id"];
 
     const parseCursor = (c: string | null | undefined) => {
-      if (!c || c === "_end_cursor") return null;
-      try {
-        return JSON.parse(c) as any[];
-      } catch {
-        return null;
-      }
+      if (!c) return null;
+      // null = undefined field; strings are JSON.stringify(convexToJson(v))
+      return (JSON.parse(c) as any[]).map((k) =>
+        k === null ? undefined : jsonToConvex(JSON.parse(k)),
+      );
     };
 
-    const cursorKeys = parseCursor(cursor);
+    const cursorKeys = cursor !== "_end_cursor" ? parseCursor(cursor) : null;
     // _end_cursor as endCursor means "to the end of the range" — no boundary
     const hasEndBoundary = !!endCursor && endCursor !== "_end_cursor";
     const endCursorKeys = hasEndBoundary ? parseCursor(endCursor) : null;
@@ -483,7 +489,7 @@ class DatabaseFake {
     // null cursor = start of range
     let isInPage = cursor === null;
     let isDone = false;
-    let continueCursor: string | null = null;
+    let continueCursor: string = "_end_cursor";
     let splitCursor: string | null = null;
     let pageStatus: "SplitRecommended" | "SplitRequired" | null = null;
     let rowsRead = 0;
@@ -495,7 +501,10 @@ class DatabaseFake {
       const isLastDoc = i === sortedDocs.length - 1;
 
       if (!isInPage) {
-        if (cursorKeys) {
+        if (cursor === "_end_cursor") {
+          // Past the end — no doc is after the end cursor
+          continue;
+        } else if (cursorKeys) {
           // Sort-key-based cursor: skip docs at or before cursor position
           if (
             this._docIsAfterCursor(doc, cursorKeys, cursorFields, order) > 0
@@ -563,9 +572,8 @@ class DatabaseFake {
       }
     }
 
-    if (continueCursor === null) {
+    if (continueCursor === "_end_cursor") {
       isDone = true;
-      continueCursor = "_end_cursor";
     }
 
     // Compute splitCursor at midpoint when limits are hit


### PR DESCRIPTION
## Add pagination with indexes and test coverage for deletion scenarios

This change enhances pagination functionality to handle document deletions properly by using field values as cursors instead of document IDs.

### Changes

- **Enhanced cursor encoding**: Pagination now uses field values from sort keys as cursors rather than relying solely on document IDs
- **Improved deletion handling**: When documents are deleted between pagination requests, the cursor remains valid by referencing field values that persist in the sort order

The implementation ensures pagination continues correctly even when documents referenced by previous cursors have been deleted, maintaining consistent results across paginated queries.

Based on Jordan's previous PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pagination now supports indexed and composite-indexed queries with multi-field sorting and explicit ascending/descending order in cursors.
  * Cursor handling improved to use multi-field sort keys (including unique tie-breaker) and to correctly manage page boundaries and continuation tokens.

* **Bug Fixes / Robustness**
  * Pagination resilient to documents deleted mid-pagination, preserving correct continuity and completion detection.

* **Tests**
  * Added tests covering deletions and pagination across indexed and composite-indexed queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->