### PR TITLE
Use ALS instead of Convex global to run tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.45-alpha.0
+
+- Replaces global usage with AsyncLocalStorage-scoped test state for isolation
+
 ## 0.0.44
 
 - More correctly implements nested transactions and parallel calls.

--- a/convex/component.ts
+++ b/convex/component.ts
@@ -169,6 +169,20 @@ export const actionCallingComponentAction = internalAction({
   },
 });
 
+export const actionSchedulingOnBothComponents = internalAction({
+  args: {},
+  handler: async (ctx): Promise<null> => {
+    // Schedule mutations on both components from an action.
+    // Each component's `schedule` mutation uses ctx.scheduler.runAfter,
+    // so this exercises setTimeout within an action across components.
+    await Promise.all([
+      ctx.runMutation(components.counter.public.schedule, { name: "beans" }),
+      ctx.runMutation(components.counter2.public.schedule, { name: "beans" }),
+    ]);
+    return null;
+  },
+});
+
 export const parallelComponentMutations = internalMutation({
   args: {},
   handler: async (ctx): Promise<null> => {

--- a/convex/components.test.ts
+++ b/convex/components.test.ts
@@ -160,6 +160,79 @@ test("auth applies to directly called component function", async () => {
   expect(name).toEqual("Sarah");
 });
 
+test("parallel actions scheduling across components via setTimeout", async () => {
+  vi.useFakeTimers();
+  const t = testWithTwoCounters();
+  // Run two actions in parallel: one on counter1, one on counter2.
+  // Meanwhile, a third action schedules mutations on both components
+  // (each component's `schedule` uses ctx.scheduler.runAfter, i.e. setTimeout).
+  const [count1, count2] = await Promise.all([
+    t.action(internal.component.actionOnCounter1),
+    t.action(internal.component.actionOnCounter2),
+    t.action(internal.component.actionSchedulingOnBothComponents),
+  ]);
+  expect(count1).toEqual(10);
+  expect(count2).toEqual(20);
+  // Now let the scheduled functions fire and complete.
+  await t.finishAllScheduledFunctions(vi.runAllTimers);
+  // Each component got +1 from the scheduled add.
+  const finalCount1 = await t.query(components.counter.public.count, {
+    name: "beans",
+  });
+  const finalCount2 = await t.query(components.counter2.public.count, {
+    name: "beans",
+  });
+  expect(finalCount1).toEqual(11);
+  expect(finalCount2).toEqual(21);
+  vi.useRealTimers();
+});
+
+test("separate convexTest instances are isolated with scheduling", async () => {
+  vi.useFakeTimers();
+  // Two completely independent test instances running in parallel.
+  // Each schedules mutations on its own components via setTimeout.
+  // They must not interfere with each other.
+  const t1 = testWithTwoCounters();
+  const t2 = testWithTwoCounters();
+
+  // Seed different data in each instance.
+  await Promise.all([
+    t1.mutation(components.counter.public.add, {
+      name: "beans",
+      count: 100,
+    }),
+    t2.mutation(components.counter.public.add, {
+      name: "beans",
+      count: 200,
+    }),
+  ]);
+
+  // Run actions that schedule via setTimeout on both instances in parallel.
+  await Promise.all([
+    t1.action(internal.component.actionSchedulingOnBothComponents),
+    t2.action(internal.component.actionSchedulingOnBothComponents),
+  ]);
+
+  // Let both instances' scheduled functions fire.
+  await Promise.all([
+    t1.finishAllScheduledFunctions(vi.runAllTimers),
+    t2.finishAllScheduledFunctions(vi.runAllTimers),
+  ]);
+
+  // Each instance's counter should reflect only its own data.
+  const count1 = await t1.query(components.counter.public.count, {
+    name: "beans",
+  });
+  const count2 = await t2.query(components.counter.public.count, {
+    name: "beans",
+  });
+  // t1: 100 (seeded) + 1 (scheduled) = 101
+  expect(count1).toEqual(101);
+  // t2: 200 (seeded) + 1 (scheduled) = 201
+  expect(count2).toEqual(201);
+  vi.useRealTimers();
+});
+
 test("parallel mutations on different components", async () => {
   const t = testWithTwoCounters();
   await t.mutation(internal.component.parallelComponentMutations);

--- a/index.ts
+++ b/index.ts
@@ -136,6 +136,7 @@ class NestedLock {
 
 const nestedTxStorage = new AsyncLocalStorage<NestedLock>();
 const authStorage = new AsyncLocalStorage<AuthFake>();
+const convexGlobalStorage = new AsyncLocalStorage<ConvexGlobal>();
 
 class DatabaseFake {
   private _componentPath: string;
@@ -1509,67 +1510,73 @@ function asyncSyscallImpl() {
           state: { kind: "pending" },
         });
         const componentPath = getCurrentComponentPath();
+        // Capture the current test's ConvexGlobal so the scheduled
+        // function callback (which runs via setTimeout, outside the
+        // original ALS context) uses the correct test state.
+        const capturedGlobal = getConvexGlobal();
         setTimeout(
           // Scheduled functions run without auth context, even if
           // they were scheduled from an authenticated function.
           (() =>
-            authStorage.run(new AuthFake(), async () => {
-              const canceled = await withAuth().runInComponent(
-                componentPath,
-                async () => {
+            convexGlobalStorage.run(capturedGlobal, () =>
+              authStorage.run(new AuthFake(), async () => {
+                const canceled = await withAuth().runInComponent(
+                  componentPath,
+                  async () => {
+                    const job = db.get(
+                      "_scheduled_functions",
+                      jobId,
+                    ) as ScheduledFunction;
+                    if (job.state.kind === "canceled") {
+                      return true;
+                    }
+                    if (job.state.kind !== "pending") {
+                      throw new Error(
+                        `\`convexTest\` invariant error: Unexpected scheduled function state when starting it: ${job.state.kind}`,
+                      );
+                    }
+                    db.patch("_scheduled_functions", jobId, {
+                      state: { kind: "inProgress" },
+                    });
+                    return false;
+                  },
+                );
+                if (canceled) {
+                  return;
+                }
+                try {
+                  await withAuth().fun(functionPath, parsedArgs);
+                } catch (error) {
+                  console.error(
+                    `Error when running scheduled function ${name}`,
+                    error,
+                  );
+                  await withAuth().runInComponent(componentPath, async () => {
+                    db.patch("_scheduled_functions", jobId, {
+                      state: { kind: "failed" },
+                      completedTime: Date.now(),
+                    });
+                  });
+                  db.jobFinished(jobId);
+                  return;
+                }
+                await withAuth().runInComponent(componentPath, async () => {
                   const job = db.get(
                     "_scheduled_functions",
                     jobId,
                   ) as ScheduledFunction;
-                  if (job.state.kind === "canceled") {
-                    return true;
-                  }
-                  if (job.state.kind !== "pending") {
+                  if (job.state.kind !== "inProgress") {
                     throw new Error(
-                      `\`convexTest\` invariant error: Unexpected scheduled function state when starting it: ${job.state.kind}`,
+                      `\`convexTest\` invariant error: Unexpected scheduled function state after it finished running: ${job.state.kind}`,
                     );
                   }
                   db.patch("_scheduled_functions", jobId, {
-                    state: { kind: "inProgress" },
-                  });
-                  return false;
-                },
-              );
-              if (canceled) {
-                return;
-              }
-              try {
-                await withAuth().fun(functionPath, parsedArgs);
-              } catch (error) {
-                console.error(
-                  `Error when running scheduled function ${name}`,
-                  error,
-                );
-                await withAuth().runInComponent(componentPath, async () => {
-                  db.patch("_scheduled_functions", jobId, {
-                    state: { kind: "failed" },
-                    completedTime: Date.now(),
+                    state: { kind: "success" },
                   });
                 });
                 db.jobFinished(jobId);
-                return;
-              }
-              await withAuth().runInComponent(componentPath, async () => {
-                const job = db.get(
-                  "_scheduled_functions",
-                  jobId,
-                ) as ScheduledFunction;
-                if (job.state.kind !== "inProgress") {
-                  throw new Error(
-                    `\`convexTest\` invariant error: Unexpected scheduled function state after it finished running: ${job.state.kind}`,
-                  );
-                }
-                db.patch("_scheduled_functions", jobId, {
-                  state: { kind: "success" },
-                });
-              });
-              db.jobFinished(jobId);
-            })) as () => void,
+              }),
+            )) as () => void,
           tsInSecs * 1000 - Date.now(),
         );
         return JSON.stringify(convexToJson(jobId));
@@ -1903,7 +1910,7 @@ function getModulesForComponent(componentPath: string) {
 }
 
 function getSyscalls() {
-  return (global as any).Convex as {
+  return getConvexGlobal() as {
     syscall: ReturnType<typeof syscallImpl>;
     asyncSyscall: ReturnType<typeof asyncSyscallImpl>;
   };
@@ -1975,15 +1982,15 @@ type ConvexGlobal = {
 };
 
 function getConvexGlobal(): ConvexGlobal {
-  return (global as unknown as { Convex: ConvexGlobal }).Convex;
+  return (
+    convexGlobalStorage.getStore() ??
+    (global as unknown as { Convex: ConvexGlobal }).Convex
+  );
 }
 
 function setConvexGlobal(convex: ConvexGlobal) {
-  if (getConvexGlobal()) {
-    if (getTransactionManager().isInTransaction()) {
-      throw new Error("test began while previous transaction was still open");
-    }
-  }
+  // Set on the real global so the Convex runtime can find syscalls.
+  // Per-test isolation is handled by convexGlobalStorage (AsyncLocalStorage).
   (global as unknown as { Convex: ConvexGlobal }).Convex = convex;
 }
 
@@ -2167,7 +2174,7 @@ export function convexTest<Schema extends GenericSchema>(
   }
 
   const rootDb = new DatabaseFake(schema ?? null, ROOT_COMPONENT_PATH);
-  setConvexGlobal({
+  const convexGlobal: ConvexGlobal = {
     components: {
       [ROOT_COMPONENT_PATH]: {
         db: rootDb,
@@ -2178,7 +2185,22 @@ export function convexTest<Schema extends GenericSchema>(
     syscall: syscallImpl(),
     asyncSyscall: asyncSyscallImpl(),
     jsSyscall: jsSyscallImpl(),
-  });
+  };
+  setConvexGlobal(convexGlobal);
+
+  // Wrap all function properties to run within this test's ALS context.
+  function wrapInContext<T extends Record<string, unknown>>(obj: T): T {
+    const result = {} as any;
+    for (const key of Object.keys(obj)) {
+      const val = (obj as any)[key];
+      result[key] =
+        typeof val === "function"
+          ? (...args: any[]) =>
+              convexGlobalStorage.run(convexGlobal, () => val(...args))
+          : val;
+    }
+    return result;
+  }
 
   return {
     withIdentity(identity: Partial<UserIdentity>) {
@@ -2187,11 +2209,13 @@ export function convexTest<Schema extends GenericSchema>(
       const issuer = identity.issuer ?? "https://convex.test";
       const tokenIdentifier =
         identity.tokenIdentifier ?? `${issuer}|${subject}`;
-      return withAuth(
-        new AuthFake({ ...identity, subject, issuer, tokenIdentifier }),
+      return wrapInContext(
+        withAuth(
+          new AuthFake({ ...identity, subject, issuer, tokenIdentifier }),
+        ),
       );
     },
-    ...withAuth(),
+    ...wrapInContext(withAuth()),
     registerComponent(
       componentPath: string,
       schema: SchemaDefinition<GenericSchema, boolean>,
@@ -2201,7 +2225,7 @@ export function convexTest<Schema extends GenericSchema>(
         db: new DatabaseFake(schema, componentPath),
         modules: moduleCache(glob),
       };
-      getConvexGlobal().components[componentPath] = componentInfo;
+      convexGlobal.components[componentPath] = componentInfo;
     },
   } as any;
 }

--- a/index.ts
+++ b/index.ts
@@ -1982,16 +1982,35 @@ type ConvexGlobal = {
 };
 
 function getConvexGlobal(): ConvexGlobal {
-  return (
-    convexGlobalStorage.getStore() ??
-    (global as unknown as { Convex: ConvexGlobal }).Convex
-  );
+  const store = convexGlobalStorage.getStore();
+  if (!store) {
+    throw new Error(
+      "No active convexTest context. " +
+        "Make sure you are calling methods on the object returned by convexTest().",
+    );
+  }
+  return store;
 }
 
-function setConvexGlobal(convex: ConvexGlobal) {
-  // Set on the real global so the Convex runtime can find syscalls.
-  // Per-test isolation is handled by convexGlobalStorage (AsyncLocalStorage).
-  (global as unknown as { Convex: ConvexGlobal }).Convex = convex;
+// Install a permanent global proxy so the Convex runtime's
+// `Convex.syscall` / `Convex.asyncSyscall` / `Convex.jsSyscall`
+// always delegate to the current test's ALS context.
+// This avoids writing per-test state to the global.
+let _globalProxyInstalled = false;
+function ensureGlobalProxy() {
+  if (_globalProxyInstalled) return;
+  _globalProxyInstalled = true;
+  (global as unknown as { Convex: ConvexGlobal }).Convex = {
+    get syscall() {
+      return getConvexGlobal().syscall;
+    },
+    get asyncSyscall() {
+      return getConvexGlobal().asyncSyscall;
+    },
+    get jsSyscall() {
+      return getConvexGlobal().jsSyscall;
+    },
+  } as ConvexGlobal;
 }
 
 class TransactionManager {
@@ -2186,7 +2205,7 @@ export function convexTest<Schema extends GenericSchema>(
     asyncSyscall: asyncSyscallImpl(),
     jsSyscall: jsSyscallImpl(),
   };
-  setConvexGlobal(convexGlobal);
+  ensureGlobalProxy();
 
   // Wrap all function properties to run within this test's ALS context.
   function wrapInContext<T extends Record<string, unknown>>(obj: T): T {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "convex-test",
-  "version": "0.0.44",
+  "version": "0.0.45-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "convex-test",
-      "version": "0.0.44",
+      "version": "0.0.45-alpha.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@edge-runtime/vm": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "convex-test",
-  "version": "0.0.44",
+  "version": "0.0.45-alpha.0",
   "description": "A JS mock of the Convex backend for testing your Convex functions.",
   "keywords": [
     "test",


### PR DESCRIPTION
use ALS for Convex data

add tests

no more global

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cross-component action scheduling capability for concurrent test scenarios.

* **Tests**
  * Expanded test coverage with new cases for multi-component scheduling behavior.

* **Chores**
  * Bumped version to 0.0.45-alpha.0.
  * Refactored test state management for enhanced context handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->