### PR TITLE
allow setTimeout to work within actions

### DIFF
--- a/convex/scheduler.test.ts
+++ b/convex/scheduler.test.ts
@@ -177,6 +177,43 @@ test("self-scheduling mutation", async () => {
   vi.useRealTimers();
 });
 
+test("scheduled action that uses setTimeout internally", async () => {
+  vi.useFakeTimers();
+  const t = convexTest(schema);
+  await t.mutation(api.scheduler.mutationSchedulingActionWithTimeout, {
+    body: "delayed action",
+  });
+  // The scheduled action uses setTimeout(resolve, 100) internally.
+  // finishAllScheduledFunctions needs to pump timers while waiting for
+  // the action to complete, otherwise it will hang.
+  await t.finishAllScheduledFunctions(vi.runAllTimers);
+  const result = await t.query(internal.scheduler.list);
+  expect(result).toMatchObject([{ body: "delayed action", author: "AI" }]);
+  vi.useRealTimers();
+});
+
+test("new convexTest after orphaned scheduled functions", async () => {
+  // First test instance: schedule something and advance timers so the
+  // setTimeout fires, but don't await finishInProgressScheduledFunctions.
+  // This leaves an in-progress function orphaned.
+  vi.useFakeTimers();
+  const t1 = convexTest(schema);
+  await t1.mutation(api.scheduler.mutationSchedulingAction, {
+    body: "orphaned",
+    delayMs: 0,
+  });
+  vi.runAllTimers();
+  // Don't call finishInProgressScheduledFunctions — leave it orphaned
+  vi.useRealTimers();
+
+  // Second test instance: should clean up the orphaned function and not throw
+  const t2 = convexTest(schema);
+  // Verify it works normally
+  await t2.mutation(api.scheduler.add, { body: "fresh", author: "test" });
+  const result = await t2.query(internal.scheduler.list);
+  expect(result).toMatchObject([{ body: "fresh", author: "test" }]);
+});
+
 test("argument serialization", async () => {
   vi.useFakeTimers();
   const t = convexTest(schema);

--- a/convex/scheduler.ts
+++ b/convex/scheduler.ts
@@ -109,6 +109,26 @@ export const actionSchedulingActionNTimes = action({
   },
 });
 
+// Action that uses setTimeout internally (e.g. simulating a delay/polling pattern)
+export const actionWithInternalSetTimeout = action({
+  args: { body: v.string() },
+  handler: async (ctx, { body }) => {
+    await new Promise<void>((resolve) => setTimeout(resolve, 100));
+    await ctx.runMutation(api.scheduler.add, { body, author: "AI" });
+  },
+});
+
+export const mutationSchedulingActionWithTimeout = mutation({
+  args: { body: v.string() },
+  handler: async (ctx, { body }) => {
+    await ctx.scheduler.runAfter(
+      0,
+      api.scheduler.actionWithInternalSetTimeout,
+      { body },
+    );
+  },
+});
+
 export const selfSchedulingMutation = mutation({
   args: {},
   handler: async (ctx) => {

--- a/index.ts
+++ b/index.ts
@@ -1514,82 +1514,71 @@ function asyncSyscallImpl() {
         // function callback (which runs via setTimeout, outside the
         // original ALS context) uses the correct test state.
         const capturedGlobal = getConvexGlobal();
-        const timers = getConvexGlobal().scheduledTimers;
-        const tm = getTransactionManager();
-        const timer = setTimeout(
+        setTimeout(
+          // Scheduled functions run without auth context, even if
+          // they were scheduled from an authenticated function.
           (() =>
             convexGlobalStorage.run(capturedGlobal, () =>
-              // Scheduled functions run without auth context, even if
-              // they were scheduled from an authenticated function.
               authStorage.run(new AuthFake(), async () => {
-                try {
-                  timers.delete(timer);
-                  const canceled = await withAuth().runInComponent(
-                    componentPath,
-                    async () => {
-                      const job = db.get(
-                        "_scheduled_functions",
-                        jobId,
-                      ) as ScheduledFunction;
-                      if (job.state.kind === "canceled") {
-                        return true;
-                      }
-                      if (job.state.kind !== "pending") {
-                        throw new Error(
-                          `\`convexTest\` invariant error: Unexpected scheduled function state when starting it: ${job.state.kind}`,
-                        );
-                      }
-                      db.patch("_scheduled_functions", jobId, {
-                        state: { kind: "inProgress" },
-                      });
-                      return false;
-                    },
-                  );
-                  if (canceled) {
-                    return;
-                  }
-                  try {
-                    await withAuth().fun(functionPath, parsedArgs);
-                  } catch (error) {
-                    console.error(
-                      `Error when running scheduled function ${name}`,
-                      error,
-                    );
-                    await withAuth().runInComponent(componentPath, async () => {
-                      db.patch("_scheduled_functions", jobId, {
-                        state: { kind: "failed" },
-                        completedTime: Date.now(),
-                      });
-                    });
-                    db.jobFinished(jobId);
-                    return;
-                  }
-                  await withAuth().runInComponent(componentPath, async () => {
+                const canceled = await withAuth().runInComponent(
+                  componentPath,
+                  async () => {
                     const job = db.get(
                       "_scheduled_functions",
                       jobId,
                     ) as ScheduledFunction;
-                    if (job.state.kind !== "inProgress") {
+                    if (job.state.kind === "canceled") {
+                      return true;
+                    }
+                    if (job.state.kind !== "pending") {
                       throw new Error(
-                        `\`convexTest\` invariant error: Unexpected scheduled function state after it finished running: ${job.state.kind}`,
+                        `\`convexTest\` invariant error: Unexpected scheduled function state when starting it: ${job.state.kind}`,
                       );
                     }
                     db.patch("_scheduled_functions", jobId, {
-                      state: { kind: "success" },
+                      state: { kind: "inProgress" },
+                    });
+                    return false;
+                  },
+                );
+                if (canceled) {
+                  return;
+                }
+                try {
+                  await withAuth().fun(functionPath, parsedArgs);
+                } catch (error) {
+                  console.error(
+                    `Error when running scheduled function ${name}`,
+                    error,
+                  );
+                  await withAuth().runInComponent(componentPath, async () => {
+                    db.patch("_scheduled_functions", jobId, {
+                      state: { kind: "failed" },
+                      completedTime: Date.now(),
                     });
                   });
                   db.jobFinished(jobId);
-                } catch (e) {
-                  // If this test instance was disposed (replaced by a new
-                  // convexTest()), silently ignore errors from orphaned functions.
-                  if (tm.disposed) return;
-                  throw e;
+                  return;
                 }
+                await withAuth().runInComponent(componentPath, async () => {
+                  const job = db.get(
+                    "_scheduled_functions",
+                    jobId,
+                  ) as ScheduledFunction;
+                  if (job.state.kind !== "inProgress") {
+                    throw new Error(
+                      `\`convexTest\` invariant error: Unexpected scheduled function state after it finished running: ${job.state.kind}`,
+                    );
+                  }
+                  db.patch("_scheduled_functions", jobId, {
+                    state: { kind: "success" },
+                  });
+                });
+                db.jobFinished(jobId);
               }),
             )) as () => void,
           tsInSecs * 1000 - Date.now(),
         );
-        timers.add(timer);
         return JSON.stringify(convexToJson(jobId));
       }
       case "1.0/actions/cancel_job": {
@@ -1989,7 +1978,6 @@ const functionStackStorage = new AsyncLocalStorage<FunctionPath[]>();
 type ConvexGlobal = {
   components: Record<string, ComponentInfo>;
   transactionManager: TransactionManager;
-  scheduledTimers: Set<ReturnType<typeof setTimeout>>;
   syscall: (op: string, args: any) => any;
   asyncSyscall: (op: string, args: any) => Promise<any>;
   jsSyscall: (op: string, args: any) => Promise<any>;
@@ -2065,11 +2053,6 @@ class TransactionManager {
       while (this._waitOnCurrentFunction !== null) {
         await this._waitOnCurrentFunction;
       }
-      if (this._disposed) {
-        throw new Error(
-          "convexTest instance was replaced - a test likely failed to exit cleanly",
-        );
-      }
       this._waitOnCurrentFunction = new Promise((resolve) => {
         this._markTransactionDone = resolve;
       });
@@ -2094,24 +2077,6 @@ class TransactionManager {
   // environment.
   isInTransaction() {
     return this._waitOnCurrentFunction !== null;
-  }
-
-  private _disposed = false;
-
-  get disposed() {
-    return this._disposed;
-  }
-
-  // Mark this transaction manager as disposed. Called when a new convexTest()
-  // replaces the global.
-  dispose() {
-    this._disposed = true;
-    // Release the lock so any awaiting functions can wake up and see _disposed.
-    if (this._markTransactionDone) {
-      this._waitOnCurrentFunction = null;
-      this._markTransactionDone();
-      this._markTransactionDone = null;
-    }
   }
 
   getHeadroomTracker(): HeadroomTracker | null {
@@ -2238,7 +2203,6 @@ export function convexTest<Schema extends GenericSchema>(
       },
     },
     transactionManager: new TransactionManager(limitsConfig),
-    scheduledTimers: new Set(),
     syscall: syscallImpl(),
     asyncSyscall: asyncSyscallImpl(),
     jsSyscall: jsSyscallImpl(),

--- a/index.ts
+++ b/index.ts
@@ -1514,71 +1514,82 @@ function asyncSyscallImpl() {
         // function callback (which runs via setTimeout, outside the
         // original ALS context) uses the correct test state.
         const capturedGlobal = getConvexGlobal();
-        setTimeout(
-          // Scheduled functions run without auth context, even if
-          // they were scheduled from an authenticated function.
+        const timers = getConvexGlobal().scheduledTimers;
+        const tm = getTransactionManager();
+        const timer = setTimeout(
           (() =>
             convexGlobalStorage.run(capturedGlobal, () =>
+              // Scheduled functions run without auth context, even if
+              // they were scheduled from an authenticated function.
               authStorage.run(new AuthFake(), async () => {
-                const canceled = await withAuth().runInComponent(
-                  componentPath,
-                  async () => {
+                try {
+                  timers.delete(timer);
+                  const canceled = await withAuth().runInComponent(
+                    componentPath,
+                    async () => {
+                      const job = db.get(
+                        "_scheduled_functions",
+                        jobId,
+                      ) as ScheduledFunction;
+                      if (job.state.kind === "canceled") {
+                        return true;
+                      }
+                      if (job.state.kind !== "pending") {
+                        throw new Error(
+                          `\`convexTest\` invariant error: Unexpected scheduled function state when starting it: ${job.state.kind}`,
+                        );
+                      }
+                      db.patch("_scheduled_functions", jobId, {
+                        state: { kind: "inProgress" },
+                      });
+                      return false;
+                    },
+                  );
+                  if (canceled) {
+                    return;
+                  }
+                  try {
+                    await withAuth().fun(functionPath, parsedArgs);
+                  } catch (error) {
+                    console.error(
+                      `Error when running scheduled function ${name}`,
+                      error,
+                    );
+                    await withAuth().runInComponent(componentPath, async () => {
+                      db.patch("_scheduled_functions", jobId, {
+                        state: { kind: "failed" },
+                        completedTime: Date.now(),
+                      });
+                    });
+                    db.jobFinished(jobId);
+                    return;
+                  }
+                  await withAuth().runInComponent(componentPath, async () => {
                     const job = db.get(
                       "_scheduled_functions",
                       jobId,
                     ) as ScheduledFunction;
-                    if (job.state.kind === "canceled") {
-                      return true;
-                    }
-                    if (job.state.kind !== "pending") {
+                    if (job.state.kind !== "inProgress") {
                       throw new Error(
-                        `\`convexTest\` invariant error: Unexpected scheduled function state when starting it: ${job.state.kind}`,
+                        `\`convexTest\` invariant error: Unexpected scheduled function state after it finished running: ${job.state.kind}`,
                       );
                     }
                     db.patch("_scheduled_functions", jobId, {
-                      state: { kind: "inProgress" },
-                    });
-                    return false;
-                  },
-                );
-                if (canceled) {
-                  return;
-                }
-                try {
-                  await withAuth().fun(functionPath, parsedArgs);
-                } catch (error) {
-                  console.error(
-                    `Error when running scheduled function ${name}`,
-                    error,
-                  );
-                  await withAuth().runInComponent(componentPath, async () => {
-                    db.patch("_scheduled_functions", jobId, {
-                      state: { kind: "failed" },
-                      completedTime: Date.now(),
+                      state: { kind: "success" },
                     });
                   });
                   db.jobFinished(jobId);
-                  return;
+                } catch (e) {
+                  // If this test instance was disposed (replaced by a new
+                  // convexTest()), silently ignore errors from orphaned functions.
+                  if (tm.disposed) return;
+                  throw e;
                 }
-                await withAuth().runInComponent(componentPath, async () => {
-                  const job = db.get(
-                    "_scheduled_functions",
-                    jobId,
-                  ) as ScheduledFunction;
-                  if (job.state.kind !== "inProgress") {
-                    throw new Error(
-                      `\`convexTest\` invariant error: Unexpected scheduled function state after it finished running: ${job.state.kind}`,
-                    );
-                  }
-                  db.patch("_scheduled_functions", jobId, {
-                    state: { kind: "success" },
-                  });
-                });
-                db.jobFinished(jobId);
               }),
             )) as () => void,
           tsInSecs * 1000 - Date.now(),
         );
+        timers.add(timer);
         return JSON.stringify(convexToJson(jobId));
       }
       case "1.0/actions/cancel_job": {
@@ -1978,6 +1989,7 @@ const functionStackStorage = new AsyncLocalStorage<FunctionPath[]>();
 type ConvexGlobal = {
   components: Record<string, ComponentInfo>;
   transactionManager: TransactionManager;
+  scheduledTimers: Set<ReturnType<typeof setTimeout>>;
   syscall: (op: string, args: any) => any;
   asyncSyscall: (op: string, args: any) => Promise<any>;
   jsSyscall: (op: string, args: any) => Promise<any>;
@@ -2053,6 +2065,11 @@ class TransactionManager {
       while (this._waitOnCurrentFunction !== null) {
         await this._waitOnCurrentFunction;
       }
+      if (this._disposed) {
+        throw new Error(
+          "convexTest instance was replaced - a test likely failed to exit cleanly",
+        );
+      }
       this._waitOnCurrentFunction = new Promise((resolve) => {
         this._markTransactionDone = resolve;
       });
@@ -2077,6 +2094,24 @@ class TransactionManager {
   // environment.
   isInTransaction() {
     return this._waitOnCurrentFunction !== null;
+  }
+
+  private _disposed = false;
+
+  get disposed() {
+    return this._disposed;
+  }
+
+  // Mark this transaction manager as disposed. Called when a new convexTest()
+  // replaces the global.
+  dispose() {
+    this._disposed = true;
+    // Release the lock so any awaiting functions can wake up and see _disposed.
+    if (this._markTransactionDone) {
+      this._waitOnCurrentFunction = null;
+      this._markTransactionDone();
+      this._markTransactionDone = null;
+    }
   }
 
   getHeadroomTracker(): HeadroomTracker | null {
@@ -2203,6 +2238,7 @@ export function convexTest<Schema extends GenericSchema>(
       },
     },
     transactionManager: new TransactionManager(limitsConfig),
+    scheduledTimers: new Set(),
     syscall: syscallImpl(),
     asyncSyscall: asyncSyscallImpl(),
     jsSyscall: jsSyscallImpl(),

--- a/index.ts
+++ b/index.ts
@@ -1849,7 +1849,9 @@ export type TestConvexForDataModel<DataModel extends GenericDataModel> = {
    *   usually `vi.runAllTimers`. This function will be called in a loop
    *   with `finishInProgressScheduledFunctions()`.
    */
-  finishAllScheduledFunctions: (advanceTimers: () => void) => Promise<void>;
+  finishAllScheduledFunctions: (
+    advanceTimers: (() => void) | (() => Promise<void>),
+  ) => Promise<void>;
 };
 
 export type TestConvexForDataModelAndIdentity<
@@ -2657,16 +2659,32 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
     },
 
     finishAllScheduledFunctions: async (
-      advanceTimers: () => void,
+      advanceTimers: (() => void) | (() => Promise<void>),
       maxIterations: number = 100,
     ): Promise<void> => {
       // Wait for all scheduled functions to finish, advancing time in between
       // each function.
       // Stop after a fixed number of iterations to avoid infinite loops.
       for (let i = 0; i < maxIterations; i++) {
-        advanceTimers();
-        const hadScheduledFunctions =
-          await waitForInProgressScheduledFunctions();
+        await advanceTimers();
+        // Keep advancing timers while waiting for scheduled functions.
+        // Actions may use setTimeout internally (e.g. for delays), and those
+        // timers need to be fired for the action to complete.
+        let done = false;
+        const waitPromise = waitForInProgressScheduledFunctions().then(
+          (had) => {
+            done = true;
+            return had;
+          },
+        );
+        // Pump timers while waiting for in-progress functions to finish.
+        // Limit pumps to avoid infinite loops with sync advanceTimers.
+        for (let pump = 0; pump < 1000 && !done; pump++) {
+          await advanceTimers();
+          // Yield to microtask queue to let job completion propagate
+          await new Promise<void>((r) => queueMicrotask(r));
+        }
+        const hadScheduledFunctions = await waitPromise;
         if (!hadScheduledFunctions) {
           return;
         }

--- a/index.ts
+++ b/index.ts
@@ -2682,9 +2682,7 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
           if (pump === maxPumps - 1 && !done) {
             throw new Error(
               "finishAllScheduledFunctions: scheduled function did not " +
-                "complete after " +
-                maxPumps +
-                " timer pumps. " +
+                `complete after ${maxPumps} timer pumps. ` +
                 "Does an action have an unresolvable setTimeout or infinite loop?",
             );
           }

--- a/index.ts
+++ b/index.ts
@@ -1849,9 +1849,7 @@ export type TestConvexForDataModel<DataModel extends GenericDataModel> = {
    *   usually `vi.runAllTimers`. This function will be called in a loop
    *   with `finishInProgressScheduledFunctions()`.
    */
-  finishAllScheduledFunctions: (
-    advanceTimers: (() => void) | (() => Promise<void>),
-  ) => Promise<void>;
+  finishAllScheduledFunctions: (advanceTimers: () => void) => Promise<void>;
 };
 
 export type TestConvexForDataModelAndIdentity<
@@ -2659,14 +2657,14 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
     },
 
     finishAllScheduledFunctions: async (
-      advanceTimers: (() => void) | (() => Promise<void>),
+      advanceTimers: () => void,
       maxIterations: number = 100,
     ): Promise<void> => {
       // Wait for all scheduled functions to finish, advancing time in between
       // each function.
       // Stop after a fixed number of iterations to avoid infinite loops.
       for (let i = 0; i < maxIterations; i++) {
-        await advanceTimers();
+        advanceTimers();
         // Actions may use setTimeout internally (e.g. for delays).
         // Keep advancing timers while waiting so those can resolve.
         let done = false;
@@ -2678,7 +2676,7 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
         );
         const maxPumps = 10000;
         for (let pump = 0; pump < maxPumps && !done; pump++) {
-          await advanceTimers();
+          advanceTimers();
           // Yield to let job completion propagate
           await new Promise<void>((r) => queueMicrotask(r));
           if (pump === maxPumps - 1 && !done) {

--- a/index.ts
+++ b/index.ts
@@ -2667,9 +2667,8 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
       // Stop after a fixed number of iterations to avoid infinite loops.
       for (let i = 0; i < maxIterations; i++) {
         await advanceTimers();
-        // Keep advancing timers while waiting for scheduled functions.
-        // Actions may use setTimeout internally (e.g. for delays), and those
-        // timers need to be fired for the action to complete.
+        // Actions may use setTimeout internally (e.g. for delays).
+        // Keep advancing timers while waiting so those can resolve.
         let done = false;
         const waitPromise = waitForInProgressScheduledFunctions().then(
           (had) => {
@@ -2677,12 +2676,20 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
             return had;
           },
         );
-        // Pump timers while waiting for in-progress functions to finish.
-        // Limit pumps to avoid infinite loops with sync advanceTimers.
-        for (let pump = 0; pump < 1000 && !done; pump++) {
+        const maxPumps = 10000;
+        for (let pump = 0; pump < maxPumps && !done; pump++) {
           await advanceTimers();
-          // Yield to microtask queue to let job completion propagate
+          // Yield to let job completion propagate
           await new Promise<void>((r) => queueMicrotask(r));
+          if (pump === maxPumps - 1 && !done) {
+            throw new Error(
+              "finishAllScheduledFunctions: scheduled function did not " +
+                "complete after " +
+                maxPumps +
+                " timer pumps. " +
+                "Does an action have an unresolvable setTimeout or infinite loop?",
+            );
+          }
         }
         const hadScheduledFunctions = await waitPromise;
         if (!hadScheduledFunctions) {


### PR DESCRIPTION
## Allow setTimeout to work within actions

Enhanced `finishAllScheduledFunctions` to support async timer advancement and continuously pump timers while waiting for scheduled functions to complete. This enables actions that use `setTimeout` internally to work properly with the test framework.

## Clean up scheduled functions

Fixed handling of orphaned scheduled functions when creating new `convexTest` instances to prevent interference between test runs.

## Tests to reproduce nondeterminism

Added test cases for scheduled actions that use `setTimeout` internally and for proper cleanup when creating new test instances after leaving scheduled functions orphaned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for scheduled functions with timeout scenarios and cleanup validation.

* **Improvements**
  * Enhanced scheduler robustness for handling concurrent operations and improved error detection for unresolvable timeout conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->