### PR TITLE
Fix TestConvex type assignability by replacing overloaded signatures

### DIFF
--- a/convex/typeAssignability.test.ts
+++ b/convex/typeAssignability.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "vitest";
+import { convexTest, TestConvex } from "../index";
+import schema from "./schema";
+import type { SchemaDefinition, GenericSchema } from "convex/server";
+
+// Reproduction: a library function that accepts a generic TestConvex
+// (like workflow.register does)
+function registerComponent(
+  t: TestConvex<SchemaDefinition<GenericSchema, boolean>>,
+  name: string = "myComponent",
+) {
+  // Library code that doesn't know the caller's schema
+  void t;
+  void name;
+}
+
+test("TestConvex with specific schema is assignable to generic TestConvex", () => {
+  const t = convexTest(schema);
+  // This is the call that fails with the overloaded call signature approach
+  registerComponent(t);
+  expect(true).toBe(true);
+});

--- a/index.ts
+++ b/index.ts
@@ -1746,15 +1746,22 @@ export type TestConvexForDataModel<DataModel extends GenericDataModel> = {
    *   the arguments will be `{}`. Not used for inline functions.
    * @returns A `Promise` of the query's result.
    */
-  query: {
-    <Query extends FunctionReference<"query", any>>(
-      query: Query,
-      ...args: OptionalRestArgs<Query>
-    ): Promise<FunctionReturnType<Query>>;
-    <Output>(
-      func: (ctx: GenericQueryCtx<DataModel>) => Promise<Output>,
-    ): Promise<Output>;
-  };
+  query: <
+    QueryOrFunc extends
+      | FunctionReference<"query", any>
+      | ((ctx: GenericQueryCtx<DataModel>) => Promise<any>),
+  >(
+    queryOrFunc: QueryOrFunc,
+    ...args: QueryOrFunc extends FunctionReference<"query", any>
+      ? OptionalRestArgs<QueryOrFunc>
+      : []
+  ) => Promise<
+    QueryOrFunc extends FunctionReference<"query", any>
+      ? FunctionReturnType<QueryOrFunc>
+      : QueryOrFunc extends (ctx: any) => Promise<infer Output>
+        ? Output
+        : never
+  >;
 
   /**
    * Call a public or internal mutation, or run an inline mutation function.
@@ -1765,15 +1772,22 @@ export type TestConvexForDataModel<DataModel extends GenericDataModel> = {
    *   the arguments will be `{}`. Not used for inline functions.
    * @returns A `Promise` of the mutation's result.
    */
-  mutation: {
-    <Mutation extends FunctionReference<"mutation", any>>(
-      mutation: Mutation,
-      ...args: OptionalRestArgs<Mutation>
-    ): Promise<FunctionReturnType<Mutation>>;
-    <Output>(
-      func: (ctx: GenericMutationCtx<DataModel>) => Promise<Output>,
-    ): Promise<Output>;
-  };
+  mutation: <
+    MutationOrFunc extends
+      | FunctionReference<"mutation", any>
+      | ((ctx: GenericMutationCtx<DataModel>) => Promise<any>),
+  >(
+    mutationOrFunc: MutationOrFunc,
+    ...args: MutationOrFunc extends FunctionReference<"mutation", any>
+      ? OptionalRestArgs<MutationOrFunc>
+      : []
+  ) => Promise<
+    MutationOrFunc extends FunctionReference<"mutation", any>
+      ? FunctionReturnType<MutationOrFunc>
+      : MutationOrFunc extends (ctx: any) => Promise<infer Output>
+        ? Output
+        : never
+  >;
 
   /**
    * Call a public or internal action, or run an inline action function.
@@ -1784,15 +1798,22 @@ export type TestConvexForDataModel<DataModel extends GenericDataModel> = {
    *   the arguments will be `{}`. Not used for inline functions.
    * @returns A `Promise` of the action's result.
    */
-  action: {
-    <Action extends FunctionReference<"action", any>>(
-      action: Action,
-      ...args: OptionalRestArgs<Action>
-    ): Promise<FunctionReturnType<Action>>;
-    <Output>(
-      func: (ctx: GenericActionCtx<DataModel>) => Promise<Output>,
-    ): Promise<Output>;
-  };
+  action: <
+    ActionOrFunc extends
+      | FunctionReference<"action", any>
+      | ((ctx: GenericActionCtx<DataModel>) => Promise<any>),
+  >(
+    actionOrFunc: ActionOrFunc,
+    ...args: ActionOrFunc extends FunctionReference<"action", any>
+      ? OptionalRestArgs<ActionOrFunc>
+      : []
+  ) => Promise<
+    ActionOrFunc extends FunctionReference<"action", any>
+      ? FunctionReturnType<ActionOrFunc>
+      : ActionOrFunc extends (ctx: any) => Promise<infer Output>
+        ? Output
+        : never
+  >;
 
   /**
    * Read from and write to the mock backend.


### PR DESCRIPTION
### TL;DR

Fixed TypeScript type assignability issue by converting overloaded method signatures to single generic methods for `query`, `mutation`, and `action` in the TestConvex API.

Previously, `TestConvex<SpecificSchema>` was not assignable to `TestConvex<GenericSchema>` due to overloaded call signatures requiring contravariance. The new single generic method approach with conditional types maintains the same functionality while ensuring proper type assignability for library functions that accept generic TestConvex instances.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive type assignability tests for generic schema handling.

* **Improvements**
  * Enhanced type definitions for `query`, `mutation`, and `action` methods with unified conditional generic signatures, enabling seamless support for both function references and inline handlers with improved type inference and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->