### PR TITLE
Fix function stack corruption in parallel cross-component queries

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -86,6 +86,12 @@ export declare const components: {
         null
       >;
       count: FunctionReference<"query", "internal", { name: string }, number>;
+      countAction: FunctionReference<
+        "action",
+        "internal",
+        { name: string },
+        number
+      >;
       countMany: FunctionReference<
         "action",
         "internal",
@@ -123,6 +129,12 @@ export declare const components: {
         null
       >;
       count: FunctionReference<"query", "internal", { name: string }, number>;
+      countAction: FunctionReference<
+        "action",
+        "internal",
+        { name: string },
+        number
+      >;
       countMany: FunctionReference<
         "action",
         "internal",

--- a/convex/component.ts
+++ b/convex/component.ts
@@ -199,3 +199,57 @@ export const parallelComponentMutations = internalMutation({
     return null;
   },
 });
+
+export const parallelSequentialComponentActions = internalAction({
+  args: {},
+  handler: async (ctx) => {
+    const [[count1a, count1b], [count2a, count2b]] = await Promise.all([
+      (async () => {
+        const a = await ctx.runAction(components.counter.public.countAction, {
+          name: "a",
+        });
+        const b = await ctx.runAction(components.counter.public.countAction, {
+          name: "b",
+        });
+        return [a, b] as const;
+      })(),
+      (async () => {
+        const a = await ctx.runAction(components.counter2.public.countAction, {
+          name: "a",
+        });
+        const b = await ctx.runAction(components.counter2.public.countAction, {
+          name: "b",
+        });
+        return [a, b] as const;
+      })(),
+    ]);
+    return { count1a, count1b, count2a, count2b };
+  },
+});
+
+export const parallelSequentialComponentQueries = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    const [[count1a, count1b], [count2a, count2b]] = await Promise.all([
+      (async () => {
+        const a = await ctx.runQuery(components.counter.public.count, {
+          name: "a",
+        });
+        const b = await ctx.runQuery(components.counter.public.count, {
+          name: "b",
+        });
+        return [a, b] as const;
+      })(),
+      (async () => {
+        const a = await ctx.runQuery(components.counter2.public.count, {
+          name: "a",
+        });
+        const b = await ctx.runQuery(components.counter2.public.count, {
+          name: "b",
+        });
+        return [a, b] as const;
+      })(),
+    ]);
+    return { count1a, count1b, count2a, count2b };
+  },
+});

--- a/convex/components.test.ts
+++ b/convex/components.test.ts
@@ -233,6 +233,32 @@ test("separate convexTest instances are isolated with scheduling", async () => {
   vi.useRealTimers();
 });
 
+test("parallel sequential cross-component queries (issue #80)", async () => {
+  const t = testWithTwoCounters();
+  const result = await t.query(
+    internal.component.parallelSequentialComponentQueries,
+  );
+  expect(result).toMatchObject({
+    count1a: 0,
+    count1b: 0,
+    count2a: 0,
+    count2b: 0,
+  });
+});
+
+test("parallel sequential cross-component actions", async () => {
+  const t = testWithTwoCounters();
+  const result = await t.action(
+    internal.component.parallelSequentialComponentActions,
+  );
+  expect(result).toMatchObject({
+    count1a: 0,
+    count1b: 0,
+    count2a: 0,
+    count2b: 0,
+  });
+});
+
 test("parallel mutations on different components", async () => {
   const t = testWithTwoCounters();
   await t.mutation(internal.component.parallelComponentMutations);

--- a/convex/counter/component/public.ts
+++ b/convex/counter/component/public.ts
@@ -94,6 +94,14 @@ export const getIdentityNameAction = action({
   },
 });
 
+export const countAction = action({
+  args: { name: v.string() },
+  returns: v.number(),
+  handler: async (ctx, args): Promise<number> => {
+    return await ctx.runQuery(api.public.count, { name: args.name });
+  },
+});
+
 export const mutationWithNumberArg = mutation({
   args: { a: v.number() },
   handler: async (_ctx, args) => {

--- a/index.ts
+++ b/index.ts
@@ -2481,27 +2481,21 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
       functionReference: FunctionReference<any, any, any, any>,
       args: any,
     ) => {
-      const functionPath = getFunctionPathFromAddress(
-        getFunctionAddress(functionReference),
-      );
+      const functionPath = getFunctionPathFromReference(functionReference);
       return await byTypeWithPath.queryFromPath(functionPath, args);
     },
     runMutation: async (
       functionReference: FunctionReference<any, any, any, any>,
       args: any,
     ) => {
-      const functionPath = getFunctionPathFromAddress(
-        getFunctionAddress(functionReference),
-      );
+      const functionPath = getFunctionPathFromReference(functionReference);
       return await byTypeWithPath.mutationFromPath(functionPath, args);
     },
     runAction: async (
       functionReference: FunctionReference<any, any, any, any>,
       args: any,
     ) => {
-      const functionPath = getFunctionPathFromAddress(
-        getFunctionAddress(functionReference),
-      );
+      const functionPath = getFunctionPathFromReference(functionReference);
       return await byTypeWithPath.actionFromPath(functionPath, args);
     },
   };
@@ -2516,8 +2510,8 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
           /* isNested */ false,
         );
       }
-      const functionPath = getFunctionPathFromAddress(
-        getFunctionAddress(functionReferenceOrHandler),
+      const functionPath = getFunctionPathFromReference(
+        functionReferenceOrHandler,
       );
       return await byTypeWithPath.queryFromPath(functionPath, args);
     },
@@ -2535,8 +2529,8 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
           /* isNested */ false,
         );
       }
-      const functionPath = getFunctionPathFromAddress(
-        getFunctionAddress(functionReferenceOrHandler),
+      const functionPath = getFunctionPathFromReference(
+        functionReferenceOrHandler,
       );
       return await byTypeWithPath.mutationFromPath(functionPath, args);
     },
@@ -2552,8 +2546,8 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
           byTypeWithPath.runAction,
         );
       }
-      const functionPath = getFunctionPathFromAddress(
-        getFunctionAddress(functionReferenceOrHandler),
+      const functionPath = getFunctionPathFromReference(
+        functionReferenceOrHandler,
       );
       return await byTypeWithPath.actionFromPath(functionPath, args);
     },
@@ -2782,6 +2776,12 @@ function getFunctionPathFromAddress(
     };
   }
   throw new Error("Function address not supported");
+}
+
+function getFunctionPathFromReference(
+  functionReference: FunctionReference<any, any, any, any>,
+) {
+  return getFunctionPathFromAddress(getFunctionAddress(functionReference));
 }
 
 type RegisteredFunctions = {

--- a/index.ts
+++ b/index.ts
@@ -1905,9 +1905,9 @@ function getTransactionManager() {
 }
 
 function getCurrentComponentPath() {
-  const functionStack = getTransactionManager().getFunctionStack();
-  const currentFunctionPath = functionStack[functionStack.length - 1];
-  return currentFunctionPath?.componentPath ?? ROOT_COMPONENT_PATH;
+  return (
+    executionContextStorage.getStore()?.componentPath ?? ROOT_COMPONENT_PATH
+  );
 }
 
 function getModules() {
@@ -1983,9 +1983,13 @@ type FunctionAddress =
   | { reference: string; name: undefined; functionHandle: undefined }
   | { functionHandle: string; name: undefined; reference: undefined };
 
-// Per-execution-context function stack. Actions create their own context
-// so parallel actions don't corrupt each other's stacks.
-const functionStackStorage = new AsyncLocalStorage<FunctionPath[]>();
+type ExecutionContext = {
+  componentPath: string;
+  udfPath: string;
+  depth: number; // 0 = top-level, 1+ = nested
+};
+
+const executionContextStorage = new AsyncLocalStorage<ExecutionContext>();
 
 type ConvexGlobal = {
   components: Record<string, ComponentInfo>;
@@ -2035,13 +2039,6 @@ class TransactionManager {
   // can run mutations in parallel.
   private _waitOnCurrentFunction: Promise<void> | null = null;
   private _markTransactionDone: (() => void) | null = null;
-  // Default function stack used when not inside an action's ALS context.
-  private _functionStack: FunctionPath[] = [];
-  // Returns the per-context function stack (ALS stack for actions, shared stack otherwise).
-  getFunctionStack(): FunctionPath[] {
-    return functionStackStorage.getStore() ?? this._functionStack;
-  }
-
   private _headroomTracker: HeadroomTracker | null = null;
   private _limitsConfig: Partial<TransactionMetrics> | boolean;
 
@@ -2049,7 +2046,7 @@ class TransactionManager {
     this._limitsConfig = limitsConfig;
   }
 
-  async begin(functionPath: FunctionPath, isNested: boolean) {
+  async begin(isNested: boolean) {
     // Take a lock only for the top-level of each transaction.
     // Nested transactions are not isolated so if you `Promise.all` on multiple
     // `ctx.runMutation` or `ctx.runQuery` calls, they won't be serialized.
@@ -2066,19 +2063,10 @@ class TransactionManager {
       });
       this._headroomTracker = new HeadroomTracker(this._limitsConfig);
     }
-    this.getFunctionStack().push(functionPath);
     const convex = getConvexGlobal();
     for (const component of Object.values(convex.components)) {
       component.db.startTransaction();
     }
-  }
-
-  beginAction(functionPath: FunctionPath) {
-    this.getFunctionStack().push(functionPath);
-  }
-
-  finishAction() {
-    this.getFunctionStack().pop();
   }
 
   // Used to distinguish between mutation and action execution
@@ -2111,7 +2099,6 @@ class TransactionManager {
     if (this._markTransactionDone === null) {
       throw new Error("Transaction not started");
     }
-    this.getFunctionStack().pop();
     if (!isNested) {
       this._headroomTracker = null;
       this._waitOnCurrentFunction = null;
@@ -2261,11 +2248,10 @@ export function convexTest<Schema extends GenericSchema>(
 
 function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
   // Auth doesn't propagate across component boundaries.
-  // Must be called before begin()/beginAction() which pushes onto functionStack.
   function authForComponent(componentPath: string) {
+    const ctx = executionContextStorage.getStore();
     const isCrossComponent =
-      getTransactionManager().getFunctionStack().length > 0 &&
-      componentPath !== getCurrentComponentPath();
+      ctx !== undefined && componentPath !== ctx.componentPath;
     return isCrossComponent ? new AuthFake() : auth;
   }
 
@@ -2290,7 +2276,14 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
 
     const authForChild = authForComponent(functionPath.componentPath);
 
-    await transactionManager.begin(functionPath, isNested);
+    const parentCtx = executionContextStorage.getStore();
+    const childCtx: ExecutionContext = {
+      componentPath: functionPath.componentPath,
+      udfPath: functionPath.udfPath,
+      depth: (parentCtx?.depth ?? 0) + 1,
+    };
+
+    await transactionManager.begin(isNested);
     try {
       const childLock = new NestedLock();
       const invokeRaw = () =>
@@ -2299,7 +2292,10 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
             invokeMutation: (args: string) => Promise<string>;
           }
         ).invokeMutation(JSON.stringify(convexToJson([parseArgs(args)])));
-      const invokeInContext = () => authStorage.run(authForChild, invokeRaw);
+      const invokeInContext = () =>
+        executionContextStorage.run(childCtx, () =>
+          authStorage.run(authForChild, invokeRaw),
+        );
 
       const rawResult = await nestedTxStorage.run(childLock, invokeInContext);
 
@@ -2330,14 +2326,24 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
 
     const authForChild = authForComponent(functionPath.componentPath);
 
-    await transactionManager.begin(functionPath, isNested);
+    const parentCtx = executionContextStorage.getStore();
+    const childCtx: ExecutionContext = {
+      componentPath: functionPath.componentPath,
+      udfPath: functionPath.udfPath,
+      depth: (parentCtx?.depth ?? 0) + 1,
+    };
+
+    await transactionManager.begin(isNested);
     try {
       const childLock = new NestedLock();
       const invokeRaw = () =>
         (
           q as unknown as { invokeQuery: (args: string) => Promise<string> }
         ).invokeQuery(JSON.stringify(convexToJson([parseArgs(args)])));
-      const invokeInContext = () => authStorage.run(authForChild, invokeRaw);
+      const invokeInContext = () =>
+        executionContextStorage.run(childCtx, () =>
+          authStorage.run(authForChild, invokeRaw),
+        );
 
       const rawResult = await nestedTxStorage.run(childLock, invokeInContext);
 
@@ -2369,33 +2375,26 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
         return handler(testCtx, innerArgs);
       },
     });
-    // Check component boundary before entering the action's own stack context,
-    // so we can see the parent's function stack.
     const authForChild = authForComponent(functionPath.componentPath);
-    // Each action gets its own function stack via ALS so parallel actions
-    // don't corrupt each other's stacks.
-    const stack: FunctionPath[] = [];
-    return await functionStackStorage.run(stack, async () => {
-      getTransactionManager().beginAction(functionPath);
+    const parentCtx = executionContextStorage.getStore();
+    const childCtx: ExecutionContext = {
+      componentPath: functionPath.componentPath,
+      udfPath: functionPath.udfPath,
+      depth: (parentCtx?.depth ?? 0) + 1,
+    };
+    return await executionContextStorage.run(childCtx, async () => {
       const requestId = "" + Math.random();
-      try {
-        const rawResult = await authStorage.run(authForChild, () =>
-          (
-            a as unknown as {
-              invokeAction: (
-                requestId: string,
-                args: string,
-              ) => Promise<string>;
-            }
-          ).invokeAction(
-            requestId,
-            JSON.stringify(convexToJson([parseArgs(args)])),
-          ),
-        );
-        return jsonToConvex(JSON.parse(rawResult)) as T;
-      } finally {
-        getTransactionManager().finishAction();
-      }
+      const rawResult = await authStorage.run(authForChild, () =>
+        (
+          a as unknown as {
+            invokeAction: (requestId: string, args: string) => Promise<string>;
+          }
+        ).invokeAction(
+          requestId,
+          JSON.stringify(convexToJson([parseArgs(args)])),
+        ),
+      );
+      return jsonToConvex(JSON.parse(rawResult)) as T;
     });
   };
 
@@ -2404,14 +2403,6 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
       functionPathOrAddress: FunctionPath | FunctionAddress,
       args: any,
     ) => {
-      // Serialize nested calls at each nesting level to prevent functionStack
-      // corruption from parallel component sub-calls (GitHub issue #80).
-      // The lock must be acquired before resolving the function address so
-      // that getCurrentComponentPath() reads a consistent function stack.
-      // Use nestedTxStorage (ALS) to detect nesting — this is per-execution-context
-      // so concurrent top-level calls from different actions correctly see themselves
-      // as non-nested, while calls from within a mutation/query handler see themselves
-      // as nested.
       const parentLock = nestedTxStorage.getStore() ?? null;
       const isNested = parentLock !== null;
       if (parentLock) {
@@ -2505,22 +2496,28 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
       functionReference: FunctionReference<any, any, any, any>,
       args: any,
     ) => {
-      const refPath = await getFunctionPathFromReference(functionReference);
-      return await byTypeWithPath.queryFromPath(refPath, args);
+      return await byTypeWithPath.queryFromPath(
+        getFunctionAddress(functionReference),
+        args,
+      );
     },
     runMutation: async (
       functionReference: FunctionReference<any, any, any, any>,
       args: any,
     ) => {
-      const refPath = await getFunctionPathFromReference(functionReference);
-      return await byTypeWithPath.mutationFromPath(refPath, args);
+      return await byTypeWithPath.mutationFromPath(
+        getFunctionAddress(functionReference),
+        args,
+      );
     },
     runAction: async (
       functionReference: FunctionReference<any, any, any, any>,
       args: any,
     ) => {
-      const refPath = await getFunctionPathFromReference(functionReference);
-      return await byTypeWithPath.actionFromPath(refPath, args);
+      return await byTypeWithPath.actionFromPath(
+        getFunctionAddress(functionReference),
+        args,
+      );
     },
   };
 
@@ -2534,10 +2531,10 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
           /* isNested */ false,
         );
       }
-      const functionPath = await getFunctionPathFromReference(
-        functionReferenceOrHandler,
+      return await byTypeWithPath.queryFromPath(
+        getFunctionAddress(functionReferenceOrHandler),
+        args,
       );
-      return await byTypeWithPath.queryFromPath(functionPath, args);
     },
 
     mutation: async (
@@ -2553,10 +2550,10 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
           /* isNested */ false,
         );
       }
-      const functionPath = await getFunctionPathFromReference(
-        functionReferenceOrHandler,
+      return await byTypeWithPath.mutationFromPath(
+        getFunctionAddress(functionReferenceOrHandler),
+        args,
       );
-      return await byTypeWithPath.mutationFromPath(functionPath, args);
     },
 
     action: async (functionReferenceOrHandler: any, args?: any) => {
@@ -2570,10 +2567,10 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
           byTypeWithPath.runAction,
         );
       }
-      const functionPath = await getFunctionPathFromReference(
-        functionReferenceOrHandler,
+      return await byTypeWithPath.actionFromPath(
+        getFunctionAddress(functionReferenceOrHandler),
+        args,
       );
-      return await byTypeWithPath.actionFromPath(functionPath, args);
     },
   };
   const run = async <T>(
@@ -2797,16 +2794,6 @@ function getFunctionPathFromAddress(
     };
   }
   throw new Error("Function address not supported");
-}
-
-async function getFunctionPathFromReference(
-  functionReference: FunctionReference<any, any, any, any>,
-) {
-  // { name: "messages:list" }
-  // { reference: "_reference/childComponent/aggregate/path/to/file/functionName" }
-  // { functionHandle: "function://<id>/<path>" }
-  const functionAddress = getFunctionAddress(functionReference);
-  return getFunctionPathFromAddress(functionAddress);
 }
 
 type RegisteredFunctions = {

--- a/index.ts
+++ b/index.ts
@@ -1438,30 +1438,18 @@ function asyncSyscallImpl() {
           args: udfArgsJson,
         } = args;
         const udfArgs = jsonToConvex(udfArgsJson);
-        const functionPath = getFunctionPathFromAddress({
-          name,
-          reference,
-          functionHandle,
-        });
+        const functionAddress = { name, reference, functionHandle };
         if (udfType === "query") {
           return JSON.stringify(
             convexToJson(
-              await withAuth().queryFromPath(
-                functionPath,
-                /* isNested */ true,
-                udfArgs,
-              ),
+              await withAuth().queryFromPath(functionAddress, udfArgs),
             ),
           );
         }
         if (udfType === "mutation") {
           return JSON.stringify(
             convexToJson(
-              await withAuth().mutationFromPath(
-                functionPath,
-                /* isNested */ true,
-                udfArgs,
-              ),
+              await withAuth().mutationFromPath(functionAddress, udfArgs),
             ),
           );
         }
@@ -1990,6 +1978,11 @@ type FunctionPath = {
   udfPath: string;
 };
 
+type FunctionAddress =
+  | { name: string; reference: undefined; functionHandle: undefined }
+  | { reference: string; name: undefined; functionHandle: undefined }
+  | { functionHandle: string; name: undefined; reference: undefined };
+
 // Per-execution-context function stack. Actions create their own context
 // so parallel actions don't corrupt each other's stacks.
 const functionStackStorage = new AsyncLocalStorage<FunctionPath[]>();
@@ -2044,10 +2037,6 @@ class TransactionManager {
   private _markTransactionDone: (() => void) | null = null;
   // Default function stack used when not inside an action's ALS context.
   private _functionStack: FunctionPath[] = [];
-  // Root-level nested lock: serializes the first layer of nested sub-transactions.
-  // Deeper layers get their own locks via AsyncLocalStorage.
-  public readonly rootNestedLock = new NestedLock();
-
   // Returns the per-context function stack (ALS stack for actions, shared stack otherwise).
   getFunctionStack(): FunctionPath[] {
     return functionStackStorage.getStore() ?? this._functionStack;
@@ -2299,17 +2288,6 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
     });
     const transactionManager = getTransactionManager();
 
-    // Serialize nested calls at each nesting level to prevent functionStack
-    // and transaction level corruption from parallel component sub-calls.
-    // Each level gets its own lock via AsyncLocalStorage so nested-within-nested
-    // parallel calls also serialize correctly within their own level.
-    const parentLock = isNested
-      ? (nestedTxStorage.getStore() ?? transactionManager.rootNestedLock)
-      : null;
-    if (parentLock) {
-      await parentLock.acquire();
-    }
-
     const authForChild = authForComponent(functionPath.componentPath);
 
     await transactionManager.begin(functionPath, isNested);
@@ -2323,24 +2301,19 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
         ).invokeMutation(JSON.stringify(convexToJson([parseArgs(args)])));
       const invokeInContext = () => authStorage.run(authForChild, invokeRaw);
 
-      const rawResult = isNested
-        ? await nestedTxStorage.run(childLock, invokeInContext)
-        : await invokeInContext();
+      const rawResult = await nestedTxStorage.run(childLock, invokeInContext);
 
       transactionManager.commit(isNested);
       return jsonToConvex(JSON.parse(rawResult)) as T;
     } catch (e) {
       transactionManager.rollback(isNested);
       throw e;
-    } finally {
-      if (parentLock) {
-        parentLock.release();
-      }
     }
   };
 
-  // Shared helper to run a query with a given handler and transaction context
-  // Used by both queryFromPath (for function references) and inline queries
+  // Shared helper to run a query with a given handler and transaction context.
+  // Used by both resolveQuery (for function references) and inline queries.
+  // Callers are responsible for acquiring the nested lock when nested.
   const runQueryWithHandler = async <T>(
     handler: (ctx: any, args: any) => T,
     args: any,
@@ -2355,14 +2328,6 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
     });
     const transactionManager = getTransactionManager();
 
-    // Serialize nested calls at each nesting level (same pattern as runTransaction).
-    const parentLock = isNested
-      ? (nestedTxStorage.getStore() ?? transactionManager.rootNestedLock)
-      : null;
-    if (parentLock) {
-      await parentLock.acquire();
-    }
-
     const authForChild = authForComponent(functionPath.componentPath);
 
     await transactionManager.begin(functionPath, isNested);
@@ -2374,21 +2339,16 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
         ).invokeQuery(JSON.stringify(convexToJson([parseArgs(args)])));
       const invokeInContext = () => authStorage.run(authForChild, invokeRaw);
 
-      const rawResult = isNested
-        ? await nestedTxStorage.run(childLock, invokeInContext)
-        : await invokeInContext();
+      const rawResult = await nestedTxStorage.run(childLock, invokeInContext);
 
       return jsonToConvex(JSON.parse(rawResult)) as T;
     } finally {
       transactionManager.rollback(isNested);
-      if (parentLock) {
-        parentLock.release();
-      }
     }
   };
 
   // Shared helper to run an action with a given handler
-  // Used by both actionFromPath (for function references) and inline actions
+  // Used by both resolveAction (for function references) and inline actions
   const runActionWithHandler = async <T>(
     handler: (ctx: any, args: any) => T,
     args: any,
@@ -2441,54 +2401,88 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
 
   const byTypeWithPath = {
     queryFromPath: async (
-      functionPath: FunctionPath,
-      isNested: boolean,
+      functionPathOrAddress: FunctionPath | FunctionAddress,
       args: any,
     ) => {
-      const resolved = await getFunctionFromPath(functionPath, "query");
-      validateValidator(resolved.args, args ?? {});
+      // Serialize nested calls at each nesting level to prevent functionStack
+      // corruption from parallel component sub-calls (GitHub issue #80).
+      // The lock must be acquired before resolving the function address so
+      // that getCurrentComponentPath() reads a consistent function stack.
+      // Use nestedTxStorage (ALS) to detect nesting — this is per-execution-context
+      // so concurrent top-level calls from different actions correctly see themselves
+      // as non-nested, while calls from within a mutation/query handler see themselves
+      // as nested.
+      const parentLock = nestedTxStorage.getStore() ?? null;
+      const isNested = parentLock !== null;
+      if (parentLock) {
+        await parentLock.acquire();
+      }
+      try {
+        const resolved = await resolveFunction(functionPathOrAddress, "query");
+        validateValidator(resolved.args, args ?? {});
 
-      const result = await runQueryWithHandler(
-        resolved.handler,
-        args,
-        resolved.functionPath,
-        isNested,
-      );
-      validateReturnValue(
-        resolved.returns,
-        result,
-        "query",
-        resolved.functionPath,
-      );
-      return result;
+        const result = await runQueryWithHandler(
+          resolved.handler,
+          args,
+          resolved.functionPath,
+          isNested,
+        );
+        validateReturnValue(
+          resolved.returns,
+          result,
+          "query",
+          resolved.functionPath,
+        );
+        return result;
+      } finally {
+        if (parentLock) {
+          parentLock.release();
+        }
+      }
     },
 
     mutationFromPath: async (
-      functionPath: FunctionPath,
-      isNested: boolean,
+      functionPathOrAddress: FunctionPath | FunctionAddress,
       args: any,
     ): Promise<Value> => {
-      const resolved = await getFunctionFromPath(functionPath, "mutation");
-      validateValidator(resolved.args, args ?? {});
+      const parentLock = nestedTxStorage.getStore() ?? null;
+      const isNested = parentLock !== null;
+      if (parentLock) {
+        await parentLock.acquire();
+      }
+      try {
+        const resolved = await resolveFunction(
+          functionPathOrAddress,
+          "mutation",
+        );
+        validateValidator(resolved.args, args ?? {});
 
-      const result = await runMutationWithHandler(
-        resolved.handler,
-        args,
-        {},
-        resolved.functionPath,
-        isNested,
-      );
-      validateReturnValue(
-        resolved.returns,
-        result,
-        "mutation",
-        resolved.functionPath,
-      );
-      return result;
+        const result = await runMutationWithHandler(
+          resolved.handler,
+          args,
+          {},
+          resolved.functionPath,
+          isNested,
+        );
+        validateReturnValue(
+          resolved.returns,
+          result,
+          "mutation",
+          resolved.functionPath,
+        );
+        return result;
+      } finally {
+        if (parentLock) {
+          parentLock.release();
+        }
+      }
     },
 
-    actionFromPath: async (functionPath: FunctionPath, args: any) => {
-      const resolved = await getFunctionFromPath(functionPath, "action");
+    actionFromPath: async (
+      functionPathOrAddress: FunctionPath | FunctionAddress,
+      args: any,
+    ) => {
+      const resolved = await resolveFunction(functionPathOrAddress, "action");
       validateValidator(resolved.args, args ?? {});
 
       const result = await runActionWithHandler(
@@ -2512,14 +2506,14 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
       args: any,
     ) => {
       const refPath = await getFunctionPathFromReference(functionReference);
-      return await byTypeWithPath.queryFromPath(refPath, false, args);
+      return await byTypeWithPath.queryFromPath(refPath, args);
     },
     runMutation: async (
       functionReference: FunctionReference<any, any, any, any>,
       args: any,
     ) => {
       const refPath = await getFunctionPathFromReference(functionReference);
-      return await byTypeWithPath.mutationFromPath(refPath, false, args);
+      return await byTypeWithPath.mutationFromPath(refPath, args);
     },
     runAction: async (
       functionReference: FunctionReference<any, any, any, any>,
@@ -2543,11 +2537,7 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
       const functionPath = await getFunctionPathFromReference(
         functionReferenceOrHandler,
       );
-      return await byTypeWithPath.queryFromPath(
-        functionPath,
-        /* isNested */ false,
-        args,
-      );
+      return await byTypeWithPath.queryFromPath(functionPath, args);
     },
 
     mutation: async (
@@ -2566,11 +2556,7 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
       const functionPath = await getFunctionPathFromReference(
         functionReferenceOrHandler,
       );
-      return await byTypeWithPath.mutationFromPath(
-        functionPath,
-        /* isNested */ false,
-        args,
-      );
+      return await byTypeWithPath.mutationFromPath(functionPath, args);
     },
 
     action: async (functionReferenceOrHandler: any, args?: any) => {
@@ -2634,20 +2620,12 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
     },
 
     fun: async (functionPath: FunctionPath, args: any) => {
-      const { func } = await getFunctionFromPath(functionPath, "any");
+      const { func } = await resolveFunction(functionPath, "any");
       if (func.isQuery) {
-        return await byTypeWithPath.queryFromPath(
-          functionPath,
-          /* isNested */ false,
-          args,
-        );
+        return await byTypeWithPath.queryFromPath(functionPath, args);
       }
       if (func.isMutation) {
-        return await byTypeWithPath.mutationFromPath(
-          functionPath,
-          /* isNested */ false,
-          args,
-        );
+        return await byTypeWithPath.mutationFromPath(functionPath, args);
       }
       if (func.isAction) {
         return await byTypeWithPath.actionFromPath(functionPath, args);
@@ -2787,10 +2765,7 @@ function parseFunctionHandle(handle: string) {
 }
 
 function getFunctionPathFromAddress(
-  functionAddress:
-    | { name: string; reference: undefined; functionHandle: undefined }
-    | { reference: string; name: undefined; functionHandle: undefined }
-    | { functionHandle: string; name: undefined; reference: undefined },
+  functionAddress: FunctionAddress,
 ): FunctionPath {
   if (functionAddress.functionHandle !== undefined) {
     return parseFunctionHandle(functionAddress.functionHandle);
@@ -2859,8 +2834,8 @@ function getHandler(func: any): (ctx: any, args: any) => any {
   return "_handler" in func ? func["_handler"] : func;
 }
 
-async function getFunctionFromPath<T extends RegisteredFunctionKind>(
-  functionPath: FunctionPath,
+async function resolveFunction<T extends RegisteredFunctionKind>(
+  functionPathOrAddress: FunctionPath | FunctionAddress,
   type: T,
 ): Promise<{
   func: RegisteredFunctions[T];
@@ -2869,6 +2844,10 @@ async function getFunctionFromPath<T extends RegisteredFunctionKind>(
   returns: ValidatorJSON | null;
   args: ValidatorJSON;
 }> {
+  const functionPath =
+    "udfPath" in functionPathOrAddress
+      ? functionPathOrAddress
+      : getFunctionPathFromAddress(functionPathOrAddress);
   // "queries/messages:list" -> ["queries/messages", "list"]
   const [modulePath, maybeExportName] = functionPath.udfPath.split(":");
   const exportName =

--- a/index.ts
+++ b/index.ts
@@ -2445,16 +2445,21 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
       isNested: boolean,
       args: any,
     ) => {
-      const func = await getFunctionFromPath(functionPath, "query");
-      validateValidator(JSON.parse((func as any).exportArgs()), args ?? {});
+      const resolved = await getFunctionFromPath(functionPath, "query");
+      validateValidator(resolved.args, args ?? {});
 
       const result = await runQueryWithHandler(
-        (ctx, a) => getHandler(func)(ctx, a),
+        resolved.handler,
         args,
-        functionPath,
+        resolved.functionPath,
         isNested,
       );
-      validateReturnValue(func, result, "query", functionPath);
+      validateReturnValue(
+        resolved.returns,
+        result,
+        "query",
+        resolved.functionPath,
+      );
       return result;
     },
 
@@ -2463,33 +2468,43 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
       isNested: boolean,
       args: any,
     ): Promise<Value> => {
-      const func = await getFunctionFromPath(functionPath, "mutation");
-      validateValidator(JSON.parse((func as any).exportArgs()), args ?? {});
+      const resolved = await getFunctionFromPath(functionPath, "mutation");
+      validateValidator(resolved.args, args ?? {});
 
       const result = await runMutationWithHandler(
-        getHandler(func),
+        resolved.handler,
         args,
         {},
-        functionPath,
+        resolved.functionPath,
         isNested,
       );
-      validateReturnValue(func, result, "mutation", functionPath);
+      validateReturnValue(
+        resolved.returns,
+        result,
+        "mutation",
+        resolved.functionPath,
+      );
       return result;
     },
 
     actionFromPath: async (functionPath: FunctionPath, args: any) => {
-      const func = await getFunctionFromPath(functionPath, "action");
-      validateValidator(JSON.parse((func as any).exportArgs()), args ?? {});
+      const resolved = await getFunctionFromPath(functionPath, "action");
+      validateValidator(resolved.args, args ?? {});
 
       const result = await runActionWithHandler(
-        getHandler(func),
+        resolved.handler,
         args,
-        functionPath,
+        resolved.functionPath,
         byTypeWithPath.runQuery,
         byTypeWithPath.runMutation,
         byTypeWithPath.runAction,
       );
-      validateReturnValue(func, result, "action", functionPath);
+      validateReturnValue(
+        resolved.returns,
+        result,
+        "action",
+        resolved.functionPath,
+      );
       return result;
     },
     runQuery: async (
@@ -2619,7 +2634,7 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
     },
 
     fun: async (functionPath: FunctionPath, args: any) => {
-      const func = await getFunctionFromPath(functionPath, "any");
+      const { func } = await getFunctionFromPath(functionPath, "any");
       if (func.isQuery) {
         return await byTypeWithPath.queryFromPath(
           functionPath,
@@ -2746,12 +2761,11 @@ function parseArgs(
 }
 
 function validateReturnValue(
-  func: any,
+  returnsValidator: ValidatorJSON | null,
   result: any,
   functionType: "query" | "mutation" | "action",
   functionPath: FunctionPath,
 ) {
-  const returnsValidator = JSON.parse(func.exportReturns());
   if (returnsValidator !== null) {
     try {
       validateValidator(returnsValidator, result);
@@ -2848,7 +2862,13 @@ function getHandler(func: any): (ctx: any, args: any) => any {
 async function getFunctionFromPath<T extends RegisteredFunctionKind>(
   functionPath: FunctionPath,
   type: T,
-): Promise<RegisteredFunctions[T]> {
+): Promise<{
+  func: RegisteredFunctions[T];
+  functionPath: FunctionPath;
+  handler: (ctx: any, args: any) => any;
+  returns: ValidatorJSON | null;
+  args: ValidatorJSON;
+}> {
   // "queries/messages:list" -> ["queries/messages", "list"]
   const [modulePath, maybeExportName] = functionPath.udfPath.split(":");
   const exportName =
@@ -2864,7 +2884,8 @@ async function getFunctionFromPath<T extends RegisteredFunctionKind>(
       `Expected a Convex function exported from module "${modulePath}" as \`${exportName}\`, but there is no such export.`,
     );
   }
-  if (typeof getHandler(func) !== "function") {
+  const handler = getHandler(func);
+  if (typeof handler !== "function") {
     throw new Error(
       `Expected a Convex function exported from module "${modulePath}" as \`${exportName}\`, but got: ${func}`,
     );
@@ -2897,7 +2918,10 @@ async function getFunctionFromPath<T extends RegisteredFunctionKind>(
       // eslint-disable-next-line @typescript-eslint/only-throw-error
       throw type satisfies never;
   }
-  return func;
+  const args = JSON.parse(func.exportArgs());
+  const returns = JSON.parse(func.exportReturns());
+
+  return { func, functionPath, handler, returns, args };
 }
 
 function simpleHash(string: string) {

--- a/index.ts
+++ b/index.ts
@@ -1438,18 +1438,20 @@ function asyncSyscallImpl() {
           args: udfArgsJson,
         } = args;
         const udfArgs = jsonToConvex(udfArgsJson);
-        const functionAddress = { name, reference, functionHandle };
+        const functionPath = getFunctionPathFromAddress({
+          name,
+          reference,
+          functionHandle,
+        });
         if (udfType === "query") {
           return JSON.stringify(
-            convexToJson(
-              await withAuth().queryFromPath(functionAddress, udfArgs),
-            ),
+            convexToJson(await withAuth().queryFromPath(functionPath, udfArgs)),
           );
         }
         if (udfType === "mutation") {
           return JSON.stringify(
             convexToJson(
-              await withAuth().mutationFromPath(functionAddress, udfArgs),
+              await withAuth().mutationFromPath(functionPath, udfArgs),
             ),
           );
         }
@@ -1481,11 +1483,8 @@ function asyncSyscallImpl() {
           args: fnArgs,
           ts: tsInSecs,
         } = args;
-        const functionPath = getFunctionPathFromAddress({
-          name,
-          reference,
-          functionHandle,
-        });
+        const functionAddress = { name, reference, functionHandle };
+        const functionPath = getFunctionPathFromAddress(functionAddress);
         // Convert args to a Convex value before storing them or passing them to the function
         const parsedArgs = jsonToConvex(fnArgs);
 
@@ -2399,17 +2398,14 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
   };
 
   const byTypeWithPath = {
-    queryFromPath: async (
-      functionPathOrAddress: FunctionPath | FunctionAddress,
-      args: any,
-    ) => {
+    queryFromPath: async (functionPath: FunctionPath, args: any) => {
       const parentLock = nestedTxStorage.getStore() ?? null;
       const isNested = parentLock !== null;
       if (parentLock) {
         await parentLock.acquire();
       }
       try {
-        const resolved = await resolveFunction(functionPathOrAddress, "query");
+        const resolved = await resolveFunction(functionPath, "query");
         validateValidator(resolved.args, args ?? {});
 
         const result = await runQueryWithHandler(
@@ -2433,7 +2429,7 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
     },
 
     mutationFromPath: async (
-      functionPathOrAddress: FunctionPath | FunctionAddress,
+      functionPath: FunctionPath,
       args: any,
     ): Promise<Value> => {
       const parentLock = nestedTxStorage.getStore() ?? null;
@@ -2442,10 +2438,7 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
         await parentLock.acquire();
       }
       try {
-        const resolved = await resolveFunction(
-          functionPathOrAddress,
-          "mutation",
-        );
+        const resolved = await resolveFunction(functionPath, "mutation");
         validateValidator(resolved.args, args ?? {});
 
         const result = await runMutationWithHandler(
@@ -2469,11 +2462,8 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
       }
     },
 
-    actionFromPath: async (
-      functionPathOrAddress: FunctionPath | FunctionAddress,
-      args: any,
-    ) => {
-      const resolved = await resolveFunction(functionPathOrAddress, "action");
+    actionFromPath: async (functionPath: FunctionPath, args: any) => {
+      const resolved = await resolveFunction(functionPath, "action");
       validateValidator(resolved.args, args ?? {});
 
       const result = await runActionWithHandler(
@@ -2496,28 +2486,28 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
       functionReference: FunctionReference<any, any, any, any>,
       args: any,
     ) => {
-      return await byTypeWithPath.queryFromPath(
+      const functionPath = getFunctionPathFromAddress(
         getFunctionAddress(functionReference),
-        args,
       );
+      return await byTypeWithPath.queryFromPath(functionPath, args);
     },
     runMutation: async (
       functionReference: FunctionReference<any, any, any, any>,
       args: any,
     ) => {
-      return await byTypeWithPath.mutationFromPath(
+      const functionPath = getFunctionPathFromAddress(
         getFunctionAddress(functionReference),
-        args,
       );
+      return await byTypeWithPath.mutationFromPath(functionPath, args);
     },
     runAction: async (
       functionReference: FunctionReference<any, any, any, any>,
       args: any,
     ) => {
-      return await byTypeWithPath.actionFromPath(
+      const functionPath = getFunctionPathFromAddress(
         getFunctionAddress(functionReference),
-        args,
       );
+      return await byTypeWithPath.actionFromPath(functionPath, args);
     },
   };
 
@@ -2531,10 +2521,10 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
           /* isNested */ false,
         );
       }
-      return await byTypeWithPath.queryFromPath(
+      const functionPath = getFunctionPathFromAddress(
         getFunctionAddress(functionReferenceOrHandler),
-        args,
       );
+      return await byTypeWithPath.queryFromPath(functionPath, args);
     },
 
     mutation: async (
@@ -2550,10 +2540,10 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
           /* isNested */ false,
         );
       }
-      return await byTypeWithPath.mutationFromPath(
+      const functionPath = getFunctionPathFromAddress(
         getFunctionAddress(functionReferenceOrHandler),
-        args,
       );
+      return await byTypeWithPath.mutationFromPath(functionPath, args);
     },
 
     action: async (functionReferenceOrHandler: any, args?: any) => {
@@ -2567,10 +2557,10 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
           byTypeWithPath.runAction,
         );
       }
-      return await byTypeWithPath.actionFromPath(
+      const functionPath = getFunctionPathFromAddress(
         getFunctionAddress(functionReferenceOrHandler),
-        args,
       );
+      return await byTypeWithPath.actionFromPath(functionPath, args);
     },
   };
   const run = async <T>(
@@ -2822,7 +2812,7 @@ function getHandler(func: any): (ctx: any, args: any) => any {
 }
 
 async function resolveFunction<T extends RegisteredFunctionKind>(
-  functionPathOrAddress: FunctionPath | FunctionAddress,
+  functionPath: FunctionPath,
   type: T,
 ): Promise<{
   func: RegisteredFunctions[T];
@@ -2831,10 +2821,6 @@ async function resolveFunction<T extends RegisteredFunctionKind>(
   returns: ValidatorJSON | null;
   args: ValidatorJSON;
 }> {
-  const functionPath =
-    "udfPath" in functionPathOrAddress
-      ? functionPathOrAddress
-      : getFunctionPathFromAddress(functionPathOrAddress);
   // "queries/messages:list" -> ["queries/messages", "list"]
   const [modulePath, maybeExportName] = functionPath.udfPath.split(":");
   const exportName =

--- a/index.ts
+++ b/index.ts
@@ -1977,11 +1977,6 @@ type FunctionPath = {
   udfPath: string;
 };
 
-type FunctionAddress =
-  | { name: string; reference: undefined; functionHandle: undefined }
-  | { reference: string; name: undefined; functionHandle: undefined }
-  | { functionHandle: string; name: undefined; reference: undefined };
-
 type ExecutionContext = {
   componentPath: string;
   udfPath: string;
@@ -2307,7 +2302,7 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
   };
 
   // Shared helper to run a query with a given handler and transaction context.
-  // Used by both resolveQuery (for function references) and inline queries.
+  // Used by both queryFromPath (for function references) and inline queries.
   // Callers are responsible for acquiring the nested lock when nested.
   const runQueryWithHandler = async <T>(
     handler: (ctx: any, args: any) => T,
@@ -2353,7 +2348,7 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
   };
 
   // Shared helper to run an action with a given handler
-  // Used by both resolveAction (for function references) and inline actions
+  // Used by both actionFromPath (for function references) and inline actions
   const runActionWithHandler = async <T>(
     handler: (ctx: any, args: any) => T,
     args: any,
@@ -2752,7 +2747,10 @@ function parseFunctionHandle(handle: string) {
 }
 
 function getFunctionPathFromAddress(
-  functionAddress: FunctionAddress,
+  functionAddress:
+    | { name: string; reference: undefined; functionHandle: undefined }
+    | { reference: string; name: undefined; functionHandle: undefined }
+    | { functionHandle: string; name: undefined; reference: undefined },
 ): FunctionPath {
   if (functionAddress.functionHandle !== undefined) {
     return parseFunctionHandle(functionAddress.functionHandle);


### PR DESCRIPTION
## Fix race condition in parallel cross-component queries

Fixes #80

This change addresses a race condition where parallel functions performing sequential cross-component queries could read incorrect component paths due to execution context corruption.

### Changes Made

**Added regression tests for issue #80:**

- New test function `parallelSequentialComponentQueries` that reproduces the race condition
- New test function `parallelSequentialComponentActions` for action-based parallel calls
- Test cases verifying parallel sequential cross-component queries and actions work correctly

**Replaced function stack with execution context:**

- Replaced `AsyncLocalStorage<FunctionPath[]>` with `AsyncLocalStorage<ExecutionContext>`
- Execution context tracks component path, UDF path, and nesting depth
- Removed shared function stack that was prone to corruption across parallel calls

**Simplified transaction management:**

- Removed complex nested lock management from transaction begin/end
- Moved lock acquisition to the call sites (`queryFromPath`, `mutationFromPath`)
- Eliminated separate action function stack tracking

**Updated function resolution:**

- Consolidated function resolution logic into `resolveFunction()` helper
- Function path resolution now happens within proper ALS execution context
- Removed `isNested` parameter from `queryFromPath` and `mutationFromPath`

The fix ensures that when multiple parallel operations perform sequential cross-component calls, each operation maintains its correct component context throughout the call chain without corrupting shared state.