### PR TITLE
Refactor scheduled function execution to use explicit timing control

### DIFF
--- a/convex/scheduler.test.ts
+++ b/convex/scheduler.test.ts
@@ -24,7 +24,7 @@ test("mutation scheduling action", async () => {
     expect(jobs).toMatchObject([{ state: { kind: "pending" } }]);
   }
 
-  vi.advanceTimersByTime(5000);
+  vi.runAllTimers();
 
   await t.finishInProgressScheduledFunctions();
 
@@ -44,7 +44,7 @@ test("mutation scheduling action then mutation fails", async () => {
     delayMs: 10000,
     body: "through scheduler",
   });
-  vi.advanceTimersByTime(10000);
+  vi.runAllTimers();
   await t.finishInProgressScheduledFunctions();
   {
     const jobs = await t.query(internal.scheduler.jobs);
@@ -78,7 +78,7 @@ test("cancel mutation", async () => {
   const jobs = await t.query(internal.scheduler.jobs);
   expect(jobs).toMatchObject([{ state: { kind: "canceled" } }]);
 
-  vi.advanceTimersByTime(10000);
+  vi.runAllTimers();
   await t.finishInProgressScheduledFunctions();
 
   const result = await t.query(internal.scheduler.list);
@@ -99,6 +99,8 @@ test("action scheduling action", async () => {
       { state: { kind: "pending" }, args: [{ body: "through scheduler" }] },
     ]);
   }
+
+  vi.runAllTimers();
 
   await t.finishInProgressScheduledFunctions();
 
@@ -137,7 +139,7 @@ test("cancel action", async () => {
   const jobs = await t.query(internal.scheduler.jobs);
   expect(jobs).toMatchObject([{ state: { kind: "canceled" } }]);
 
-  vi.advanceTimersByTime(10000);
+  vi.runAllTimers();
   await t.finishInProgressScheduledFunctions();
 
   const result = await t.query(internal.scheduler.list);
@@ -152,6 +154,7 @@ test("failed scheduled function", async () => {
     delayMs: 0,
     body: "FAIL THIS",
   });
+  vi.runAllTimers();
   await t.finishInProgressScheduledFunctions();
   // Regression test: previously this would throw an error that the scheduled
   // function state is "failed" while it should be "inProgress".
@@ -181,30 +184,31 @@ test("scheduled action that uses setTimeout internally", async () => {
     body: "delayed action",
   });
   // The scheduled action uses setTimeout(resolve, 100) internally.
-  // finishAllScheduledFunctions pumps timers while waiting for each
-  // function to complete, so internal setTimeouts resolve naturally.
+  // finishAllScheduledFunctions needs to pump timers while waiting for
+  // the action to complete, otherwise it will hang.
   await t.finishAllScheduledFunctions(vi.runAllTimers);
   const result = await t.query(internal.scheduler.list);
   expect(result).toMatchObject([{ body: "delayed action", author: "AI" }]);
   vi.useRealTimers();
 });
 
-test("new convexTest after abandoned scheduled functions", async () => {
-  // First test instance: schedule something but don't run it.
-  // Since scheduled functions are not triggered by setTimeout, the function
-  // just stays "pending" and is abandoned when t1 goes away.
+test("new convexTest after orphaned scheduled functions", async () => {
+  // First test instance: schedule something and advance timers so the
+  // setTimeout fires, but don't await finishInProgressScheduledFunctions.
+  // This leaves an in-progress function orphaned.
   vi.useFakeTimers();
   const t1 = convexTest(schema);
   await t1.mutation(api.scheduler.mutationSchedulingAction, {
-    body: "abandoned",
+    body: "orphaned",
     delayMs: 0,
   });
-  // Don't call finishInProgressScheduledFunctions — leave it abandoned
+  vi.runAllTimers();
+  // Don't call finishInProgressScheduledFunctions — leave it orphaned
   vi.useRealTimers();
 
-  // Second test instance: should work normally since each convexTest
-  // has its own isolated state.
+  // Second test instance: should clean up the orphaned function and not throw
   const t2 = convexTest(schema);
+  // Verify it works normally
   await t2.mutation(api.scheduler.add, { body: "fresh", author: "test" });
   const result = await t2.query(internal.scheduler.list);
   expect(result).toMatchObject([{ body: "fresh", author: "test" }]);
@@ -235,7 +239,7 @@ test("argument serialization", async () => {
     expect(jobs).toMatchObject([{ state: { kind: "pending" } }]);
   }
 
-  vi.advanceTimersByTime(5000);
+  vi.runAllTimers();
 
   await t.finishInProgressScheduledFunctions();
 

--- a/convex/scheduler.test.ts
+++ b/convex/scheduler.test.ts
@@ -177,6 +177,43 @@ test("self-scheduling mutation", async () => {
   vi.useRealTimers();
 });
 
+test("scheduled action that uses setTimeout internally", async () => {
+  vi.useFakeTimers();
+  const t = convexTest(schema);
+  await t.mutation(api.scheduler.mutationSchedulingActionWithTimeout, {
+    body: "delayed action",
+  });
+  // The scheduled action uses setTimeout(resolve, 100) internally.
+  // finishAllScheduledFunctions needs to pump timers while waiting for
+  // the action to complete, otherwise it will hang.
+  await t.finishAllScheduledFunctions(vi.runAllTimers);
+  const result = await t.query(internal.scheduler.list);
+  expect(result).toMatchObject([{ body: "delayed action", author: "AI" }]);
+  vi.useRealTimers();
+});
+
+test("new convexTest after orphaned scheduled functions", async () => {
+  // First test instance: schedule something and advance timers so the
+  // setTimeout fires, but don't await finishInProgressScheduledFunctions.
+  // This leaves an in-progress function orphaned.
+  vi.useFakeTimers();
+  const t1 = convexTest(schema);
+  await t1.mutation(api.scheduler.mutationSchedulingAction, {
+    body: "orphaned",
+    delayMs: 0,
+  });
+  vi.runAllTimers();
+  // Don't call finishInProgressScheduledFunctions — leave it orphaned
+  vi.useRealTimers();
+
+  // Second test instance: should clean up the orphaned function and not throw
+  const t2 = convexTest(schema);
+  // Verify it works normally
+  await t2.mutation(api.scheduler.add, { body: "fresh", author: "test" });
+  const result = await t2.query(internal.scheduler.list);
+  expect(result).toMatchObject([{ body: "fresh", author: "test" }]);
+});
+
 test("argument serialization", async () => {
   vi.useFakeTimers();
   const t = convexTest(schema);

--- a/convex/scheduler.test.ts
+++ b/convex/scheduler.test.ts
@@ -214,6 +214,86 @@ test("new convexTest after orphaned scheduled functions", async () => {
   expect(result).toMatchObject([{ body: "fresh", author: "test" }]);
 });
 
+test("finishInProgressScheduledFunctions runs only ready functions", async () => {
+  // This tests that functions scheduled for the future don't run
+  // when only immediate functions should execute.
+  vi.useFakeTimers();
+  const t = convexTest(schema);
+  await t.mutation(api.scheduler.scheduleNowAndLater, {});
+
+  // Only run ready functions (the immediate one), not future ones
+  await t.finishInProgressScheduledFunctions();
+
+  const result = await t.query(internal.scheduler.list);
+  // Only the immediate function should have run
+  expect(result).toMatchObject([{ body: "immediate" }]);
+
+  const jobs = await t.query(internal.scheduler.jobs);
+  const pending = jobs.filter(
+    (j: { state: { kind: string } }) => j.state.kind === "pending",
+  );
+  const success = jobs.filter(
+    (j: { state: { kind: string } }) => j.state.kind === "success",
+  );
+  expect(pending).toHaveLength(1); // the delayed one is still pending
+  expect(success).toHaveLength(1); // the immediate one succeeded
+  vi.useRealTimers();
+});
+
+test("scheduled functions don't fire during unrelated function execution", async () => {
+  // On main, scheduled functions execute via setTimeout callbacks,
+  // which can fire in the middle of other function executions.
+  // With the explicit scheduler, functions only run when you call
+  // finishInProgressScheduledFunctions or finishAllScheduledFunctions.
+  vi.useFakeTimers();
+  const t = convexTest(schema);
+
+  // Schedule a function for delay=0
+  await t.mutation(api.scheduler.mutationSchedulingAction, {
+    body: "scheduled",
+    delayMs: 0,
+  });
+
+  // Advance timers — on main this would trigger the scheduled function's
+  // setTimeout callback. With explicit scheduler, nothing executes.
+  vi.runAllTimers();
+
+  // The scheduled function should still be pending (not automatically executed)
+  // until we explicitly call finishInProgressScheduledFunctions
+  const jobsBefore = await t.query(internal.scheduler.jobs);
+  expect(jobsBefore).toMatchObject([{ state: { kind: "pending" } }]);
+
+  // Now explicitly run it
+  await t.finishInProgressScheduledFunctions();
+
+  const jobsAfter = await t.query(internal.scheduler.jobs);
+  expect(jobsAfter).toMatchObject([{ state: { kind: "success" } }]);
+  vi.useRealTimers();
+});
+
+test("finishInProgressScheduledFunctions without prior vi.runAllTimers", async () => {
+  // On main, finishInProgressScheduledFunctions only waits for already
+  // in-progress functions — it doesn't find and execute pending ones.
+  // With the explicit scheduler, it also runs pending functions whose
+  // scheduledTime <= Date.now(), so no vi.runAllTimers() is needed
+  // for delay=0 scheduled functions.
+  vi.useFakeTimers();
+  const t = convexTest(schema);
+  await t.mutation(api.scheduler.mutationSchedulingAction, {
+    body: "no timers needed",
+    delayMs: 0,
+  });
+
+  // Don't call vi.runAllTimers() — just call finishInProgressScheduledFunctions
+  await t.finishInProgressScheduledFunctions();
+
+  const result = await t.query(internal.scheduler.list);
+  expect(result).toMatchObject([{ body: "no timers needed", author: "AI" }]);
+  const jobs = await t.query(internal.scheduler.jobs);
+  expect(jobs).toMatchObject([{ state: { kind: "success" } }]);
+  vi.useRealTimers();
+});
+
 test("argument serialization", async () => {
   vi.useFakeTimers();
   const t = convexTest(schema);

--- a/convex/scheduler.test.ts
+++ b/convex/scheduler.test.ts
@@ -24,7 +24,7 @@ test("mutation scheduling action", async () => {
     expect(jobs).toMatchObject([{ state: { kind: "pending" } }]);
   }
 
-  vi.runAllTimers();
+  vi.advanceTimersByTime(5000);
 
   await t.finishInProgressScheduledFunctions();
 
@@ -44,7 +44,7 @@ test("mutation scheduling action then mutation fails", async () => {
     delayMs: 10000,
     body: "through scheduler",
   });
-  vi.runAllTimers();
+  vi.advanceTimersByTime(10000);
   await t.finishInProgressScheduledFunctions();
   {
     const jobs = await t.query(internal.scheduler.jobs);
@@ -78,7 +78,7 @@ test("cancel mutation", async () => {
   const jobs = await t.query(internal.scheduler.jobs);
   expect(jobs).toMatchObject([{ state: { kind: "canceled" } }]);
 
-  vi.runAllTimers();
+  vi.advanceTimersByTime(10000);
   await t.finishInProgressScheduledFunctions();
 
   const result = await t.query(internal.scheduler.list);
@@ -99,8 +99,6 @@ test("action scheduling action", async () => {
       { state: { kind: "pending" }, args: [{ body: "through scheduler" }] },
     ]);
   }
-
-  vi.runAllTimers();
 
   await t.finishInProgressScheduledFunctions();
 
@@ -139,7 +137,7 @@ test("cancel action", async () => {
   const jobs = await t.query(internal.scheduler.jobs);
   expect(jobs).toMatchObject([{ state: { kind: "canceled" } }]);
 
-  vi.runAllTimers();
+  vi.advanceTimersByTime(10000);
   await t.finishInProgressScheduledFunctions();
 
   const result = await t.query(internal.scheduler.list);
@@ -154,7 +152,6 @@ test("failed scheduled function", async () => {
     delayMs: 0,
     body: "FAIL THIS",
   });
-  vi.runAllTimers();
   await t.finishInProgressScheduledFunctions();
   // Regression test: previously this would throw an error that the scheduled
   // function state is "failed" while it should be "inProgress".
@@ -184,31 +181,30 @@ test("scheduled action that uses setTimeout internally", async () => {
     body: "delayed action",
   });
   // The scheduled action uses setTimeout(resolve, 100) internally.
-  // finishAllScheduledFunctions needs to pump timers while waiting for
-  // the action to complete, otherwise it will hang.
+  // finishAllScheduledFunctions pumps timers while waiting for each
+  // function to complete, so internal setTimeouts resolve naturally.
   await t.finishAllScheduledFunctions(vi.runAllTimers);
   const result = await t.query(internal.scheduler.list);
   expect(result).toMatchObject([{ body: "delayed action", author: "AI" }]);
   vi.useRealTimers();
 });
 
-test("new convexTest after orphaned scheduled functions", async () => {
-  // First test instance: schedule something and advance timers so the
-  // setTimeout fires, but don't await finishInProgressScheduledFunctions.
-  // This leaves an in-progress function orphaned.
+test("new convexTest after abandoned scheduled functions", async () => {
+  // First test instance: schedule something but don't run it.
+  // Since scheduled functions are not triggered by setTimeout, the function
+  // just stays "pending" and is abandoned when t1 goes away.
   vi.useFakeTimers();
   const t1 = convexTest(schema);
   await t1.mutation(api.scheduler.mutationSchedulingAction, {
-    body: "orphaned",
+    body: "abandoned",
     delayMs: 0,
   });
-  vi.runAllTimers();
-  // Don't call finishInProgressScheduledFunctions — leave it orphaned
+  // Don't call finishInProgressScheduledFunctions — leave it abandoned
   vi.useRealTimers();
 
-  // Second test instance: should clean up the orphaned function and not throw
+  // Second test instance: should work normally since each convexTest
+  // has its own isolated state.
   const t2 = convexTest(schema);
-  // Verify it works normally
   await t2.mutation(api.scheduler.add, { body: "fresh", author: "test" });
   const result = await t2.query(internal.scheduler.list);
   expect(result).toMatchObject([{ body: "fresh", author: "test" }]);
@@ -239,7 +235,7 @@ test("argument serialization", async () => {
     expect(jobs).toMatchObject([{ state: { kind: "pending" } }]);
   }
 
-  vi.runAllTimers();
+  vi.advanceTimersByTime(5000);
 
   await t.finishInProgressScheduledFunctions();
 

--- a/convex/scheduler.test.ts
+++ b/convex/scheduler.test.ts
@@ -177,43 +177,6 @@ test("self-scheduling mutation", async () => {
   vi.useRealTimers();
 });
 
-test("scheduled action that uses setTimeout internally", async () => {
-  vi.useFakeTimers();
-  const t = convexTest(schema);
-  await t.mutation(api.scheduler.mutationSchedulingActionWithTimeout, {
-    body: "delayed action",
-  });
-  // The scheduled action uses setTimeout(resolve, 100) internally.
-  // finishAllScheduledFunctions needs to pump timers while waiting for
-  // the action to complete, otherwise it will hang.
-  await t.finishAllScheduledFunctions(vi.runAllTimers);
-  const result = await t.query(internal.scheduler.list);
-  expect(result).toMatchObject([{ body: "delayed action", author: "AI" }]);
-  vi.useRealTimers();
-});
-
-test("new convexTest after orphaned scheduled functions", async () => {
-  // First test instance: schedule something and advance timers so the
-  // setTimeout fires, but don't await finishInProgressScheduledFunctions.
-  // This leaves an in-progress function orphaned.
-  vi.useFakeTimers();
-  const t1 = convexTest(schema);
-  await t1.mutation(api.scheduler.mutationSchedulingAction, {
-    body: "orphaned",
-    delayMs: 0,
-  });
-  vi.runAllTimers();
-  // Don't call finishInProgressScheduledFunctions — leave it orphaned
-  vi.useRealTimers();
-
-  // Second test instance: should clean up the orphaned function and not throw
-  const t2 = convexTest(schema);
-  // Verify it works normally
-  await t2.mutation(api.scheduler.add, { body: "fresh", author: "test" });
-  const result = await t2.query(internal.scheduler.list);
-  expect(result).toMatchObject([{ body: "fresh", author: "test" }]);
-});
-
 test("argument serialization", async () => {
   vi.useFakeTimers();
   const t = convexTest(schema);

--- a/convex/scheduler.ts
+++ b/convex/scheduler.ts
@@ -109,26 +109,6 @@ export const actionSchedulingActionNTimes = action({
   },
 });
 
-// Action that uses setTimeout internally (e.g. simulating a delay/polling pattern)
-export const actionWithInternalSetTimeout = action({
-  args: { body: v.string() },
-  handler: async (ctx, { body }) => {
-    await new Promise<void>((resolve) => setTimeout(resolve, 100));
-    await ctx.runMutation(api.scheduler.add, { body, author: "AI" });
-  },
-});
-
-export const mutationSchedulingActionWithTimeout = mutation({
-  args: { body: v.string() },
-  handler: async (ctx, { body }) => {
-    await ctx.scheduler.runAfter(
-      0,
-      api.scheduler.actionWithInternalSetTimeout,
-      { body },
-    );
-  },
-});
-
 export const selfSchedulingMutation = mutation({
   args: {},
   handler: async (ctx) => {

--- a/convex/scheduler.ts
+++ b/convex/scheduler.ts
@@ -109,6 +109,26 @@ export const actionSchedulingActionNTimes = action({
   },
 });
 
+// Action that uses setTimeout internally (e.g. simulating a delay/polling pattern)
+export const actionWithInternalSetTimeout = action({
+  args: { body: v.string() },
+  handler: async (ctx, { body }) => {
+    await new Promise<void>((resolve) => setTimeout(resolve, 100));
+    await ctx.runMutation(api.scheduler.add, { body, author: "AI" });
+  },
+});
+
+export const mutationSchedulingActionWithTimeout = mutation({
+  args: { body: v.string() },
+  handler: async (ctx, { body }) => {
+    await ctx.scheduler.runAfter(
+      0,
+      api.scheduler.actionWithInternalSetTimeout,
+      { body },
+    );
+  },
+});
+
 export const selfSchedulingMutation = mutation({
   args: {},
   handler: async (ctx) => {

--- a/convex/scheduler.ts
+++ b/convex/scheduler.ts
@@ -139,3 +139,18 @@ export const selfSchedulingMutation = mutation({
     );
   },
 });
+
+// Mutation that schedules two things: one now and one in the future
+export const scheduleNowAndLater = mutation({
+  args: {},
+  handler: async (ctx) => {
+    await ctx.scheduler.runAfter(0, api.scheduler.add, {
+      body: "immediate",
+      author: "AI",
+    });
+    await ctx.scheduler.runAfter(60000, api.scheduler.add, {
+      body: "delayed",
+      author: "AI",
+    });
+  },
+});

--- a/index.ts
+++ b/index.ts
@@ -1579,6 +1579,13 @@ function asyncSyscallImpl() {
           `${sourceComponent}:${jobId}`,
           functionPath,
         );
+        // Create a time-marker setTimeout so that vi.runAllTimers() or
+        // vi.advanceTimersByTime(ms) advances the clock past this
+        // function's scheduled time. The callback is intentionally empty —
+        // execution is handled explicitly by finishInProgressScheduledFunctions
+        // / finishAllScheduledFunctions.
+        const delay = Math.max(0, tsInSecs * 1000 - Date.now());
+        setTimeout(() => {}, delay);
         return JSON.stringify(convexToJson(jobId));
       }
       case "1.0/actions/cancel_job": {
@@ -2017,12 +2024,10 @@ export type TestConvexForDataModel<DataModel extends GenericDataModel> = {
    *
    * Use in combination with `vi.useFakeTimers()` to test scheduled functions.
    *
-   * @param advanceTimers Function that advances timers, e.g.
-   *   `vi.advanceTimersByTime` or `vi.runAllTimers`.
+   * @param advanceTimers Function that advances timers,
+   *   usually `vi.runAllTimers`.
    */
-  finishAllScheduledFunctions: (
-    advanceTimers: (() => void) | ((ms: number) => void),
-  ) => Promise<void>;
+  finishAllScheduledFunctions: (advanceTimers: () => void) => Promise<void>;
 };
 
 export type TestConvexForDataModelAndIdentity<
@@ -2895,7 +2900,7 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
     },
 
     finishAllScheduledFunctions: async (
-      advanceTimers: (() => void) | ((ms: number) => void),
+      advanceTimers: () => void,
       maxIterations: number = 100,
     ): Promise<void> => {
       const convexGlobal = getConvexGlobal();
@@ -2903,17 +2908,12 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
       // function's scheduledTime. Stop after a fixed number of iterations
       // to detect infinitely recursive schedules.
       for (let i = 0; i < maxIterations; i++) {
+        // Advance timers to fire scheduling-time markers, moving the
+        // clock past pending functions' scheduled times.
+        advanceTimers();
         const next = await findEarliestPendingFunction(convexGlobal);
-        if (next === null) {
+        if (next === null || next.scheduledTime > Date.now()) {
           return;
-        }
-        const delta = Math.max(0, next.scheduledTime - Date.now());
-        if (delta > 0) {
-          // Create a setTimeout marker so that advanceTimers (whether
-          // vi.runAllTimers or vi.advanceTimersByTime) advances the
-          // clock to the scheduled function's time.
-          setTimeout(() => {}, delta);
-          advanceTimers(delta);
         }
         // Execute the function while pumping timers so that any internal
         // setTimeout calls (e.g. in actions) can resolve. This is safe
@@ -2929,9 +2929,9 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
         });
         const maxPumps = 10000;
         for (let pump = 0; pump < maxPumps && !done; pump++) {
-          // Create a 1ms marker and advance to fire any pending timers.
-          setTimeout(() => {}, 1);
-          advanceTimers(1);
+          // Advance timers to fire any pending internal timers
+          // (e.g. setTimeout in actions) and any new scheduling markers.
+          advanceTimers();
           // Yield through a full event loop iteration so that dynamic
           // import() calls (used to load function modules) can resolve.
           await new Promise<void>((r) => {

--- a/index.ts
+++ b/index.ts
@@ -1571,75 +1571,13 @@ function asyncSyscallImpl() {
           scheduledTime: tsInSecs * 1000,
           state: { kind: "pending" },
         });
-        const componentPath = getCurrentComponentPath();
-        // Capture the current test's ConvexGlobal so the scheduled
-        // function callback (which runs via setTimeout, outside the
-        // original ALS context) uses the correct test state.
-        const capturedGlobal = getConvexGlobal();
-        setTimeout(
-          // Scheduled functions run without auth context, even if
-          // they were scheduled from an authenticated function.
-          (() =>
-            convexGlobalStorage.run(capturedGlobal, () =>
-              authStorage.run(new AuthFake(), async () => {
-                const canceled = await withAuth().runInComponent(
-                  componentPath,
-                  async () => {
-                    const job = db.get("_scheduled_functions", jobId) as
-                      | ScheduledFunction
-                      | undefined;
-                    if (!job) return true;
-                    if (job.state.kind === "canceled") {
-                      return true;
-                    }
-                    if (job.state.kind !== "pending") {
-                      throw new Error(
-                        `\`convexTest\` invariant error: Unexpected scheduled function state when starting it: ${job.state.kind}`,
-                      );
-                    }
-                    db.patch("_scheduled_functions", jobId, {
-                      state: { kind: "inProgress" },
-                    });
-                    return false;
-                  },
-                );
-                if (canceled) {
-                  return;
-                }
-                try {
-                  await withAuth().fun(functionPath, parsedArgs);
-                } catch (error) {
-                  console.error(
-                    `Error when running scheduled function ${name}`,
-                    error,
-                  );
-                  await withAuth().runInComponent(componentPath, async () => {
-                    db.patch("_scheduled_functions", jobId, {
-                      state: { kind: "failed" },
-                      completedTime: Date.now(),
-                    });
-                  });
-                  db.jobFinished(jobId);
-                  return;
-                }
-                await withAuth().runInComponent(componentPath, async () => {
-                  const job = db.get(
-                    "_scheduled_functions",
-                    jobId,
-                  ) as ScheduledFunction;
-                  if (job.state.kind !== "inProgress") {
-                    throw new Error(
-                      `\`convexTest\` invariant error: Unexpected scheduled function state after it finished running: ${job.state.kind}`,
-                    );
-                  }
-                  db.patch("_scheduled_functions", jobId, {
-                    state: { kind: "success" },
-                  });
-                });
-                db.jobFinished(jobId);
-              }),
-            )) as () => void,
-          tsInSecs * 1000 - Date.now(),
+        // Store the resolved function path so executeScheduledFunction
+        // can find the correct component (especially for function handles
+        // that resolve to a different component).
+        const sourceComponent = getCurrentComponentPath();
+        getConvexGlobal().scheduledFunctionPaths.set(
+          `${sourceComponent}:${jobId}`,
+          functionPath,
         );
         return JSON.stringify(convexToJson(jobId));
       }
@@ -1795,6 +1733,151 @@ async function waitForInProgressScheduledFunctions(): Promise<boolean> {
   return hadScheduledFunctions;
 }
 
+/**
+ * Execute a single scheduled function by its job ID and component path.
+ * Handles state transitions, error handling, and job completion notification.
+ */
+async function executeScheduledFunction(
+  capturedGlobal: ConvexGlobal,
+  sourceComponentPath: string,
+  jobId: GenericId<"_scheduled_functions">,
+): Promise<void> {
+  await convexGlobalStorage.run(capturedGlobal, () =>
+    authStorage.run(new AuthFake(), async () => {
+      const db = getDbForComponent(sourceComponentPath);
+      const job = db.get("_scheduled_functions", jobId) as ScheduledFunction;
+      // Use the resolved function path if available (needed for function
+      // handles that target a different component). Fall back to
+      // reconstructing from the source component and stored name.
+      const functionPath: FunctionPath =
+        capturedGlobal.scheduledFunctionPaths.get(
+          `${sourceComponentPath}:${jobId}`,
+        ) ?? {
+          componentPath: sourceComponentPath,
+          udfPath: String(job.name),
+        };
+      const parsedArgs = (job.args as any)[0];
+
+      const canceled = await withAuth().runInComponent(
+        sourceComponentPath,
+        async () => {
+          if (job.state.kind === "canceled") {
+            return true;
+          }
+          if (job.state.kind !== "pending") {
+            throw new Error(
+              `\`convexTest\` invariant error: Unexpected scheduled function state when starting it: ${job.state.kind}`,
+            );
+          }
+          db.patch("_scheduled_functions", jobId, {
+            state: { kind: "inProgress" },
+          });
+          return false;
+        },
+      );
+      if (canceled) {
+        return;
+      }
+      try {
+        await withAuth().fun(functionPath, parsedArgs);
+      } catch (error) {
+        console.error(
+          `Error when running scheduled function ${job.name}`,
+          error,
+        );
+        await withAuth().runInComponent(sourceComponentPath, async () => {
+          db.patch("_scheduled_functions", jobId, {
+            state: { kind: "failed" },
+            completedTime: Date.now(),
+          });
+        });
+        db.jobFinished(jobId);
+        return;
+      }
+      await withAuth().runInComponent(sourceComponentPath, async () => {
+        const updatedJob = db.get(
+          "_scheduled_functions",
+          jobId,
+        ) as ScheduledFunction;
+        if (updatedJob.state.kind !== "inProgress") {
+          throw new Error(
+            `\`convexTest\` invariant error: Unexpected scheduled function state after it finished running: ${updatedJob.state.kind}`,
+          );
+        }
+        db.patch("_scheduled_functions", jobId, {
+          state: { kind: "success" },
+        });
+      });
+      db.jobFinished(jobId);
+    }),
+  );
+}
+
+/**
+ * Find the earliest pending scheduled function across all components.
+ * Returns null if no pending functions exist.
+ */
+async function findEarliestPendingFunction(
+  convexGlobal: ConvexGlobal,
+): Promise<{
+  componentPath: string;
+  jobId: GenericId<"_scheduled_functions">;
+  scheduledTime: number;
+} | null> {
+  let earliest: {
+    componentPath: string;
+    jobId: GenericId<"_scheduled_functions">;
+    scheduledTime: number;
+  } | null = null;
+
+  for (const componentPath of Object.keys(convexGlobal.components)) {
+    const pendingJobs = (await withAuth().runInComponent(
+      componentPath,
+      async (ctx) => {
+        return (
+          await ctx.db.system.query("_scheduled_functions").collect()
+        ).filter((job: ScheduledFunction) => job.state.kind === "pending");
+      },
+    )) as ScheduledFunction[];
+
+    for (const job of pendingJobs) {
+      const scheduledTime = job.scheduledTime;
+      if (earliest === null || scheduledTime < earliest.scheduledTime) {
+        earliest = {
+          componentPath,
+          jobId: job._id,
+          scheduledTime,
+        };
+      }
+    }
+  }
+
+  return earliest;
+}
+
+/**
+ * Run all pending scheduled functions whose scheduledTime <= Date.now(),
+ * one at a time in order of scheduledTime. Returns true if any were run.
+ */
+async function runReadyScheduledFunctions(
+  convexGlobal: ConvexGlobal,
+): Promise<boolean> {
+  let ranAny = false;
+  for (;;) {
+    const next = await findEarliestPendingFunction(convexGlobal);
+    if (next === null || next.scheduledTime > Date.now()) {
+      break;
+    }
+    await executeScheduledFunction(
+      convexGlobal,
+      next.componentPath,
+      next.jobId,
+    );
+    ranAny = true;
+  }
+  return ranAny;
+}
+
 export type TestConvex<SchemaDef extends SchemaDefinition<any, boolean>> =
   TestConvexForDataModelAndIdentity<DataModelFromSchemaDefinition<SchemaDef>>;
 
@@ -1909,30 +1992,37 @@ export type TestConvexForDataModel<DataModel extends GenericDataModel> = {
   fetch(pathQueryFragment: string, init?: RequestInit): Promise<Response>;
 
   /**
-   * Wait for all scheduled functions currently in the "inProgress" state
-   * to either finish successfully or fail.
+   * Run all pending scheduled functions whose scheduled time has passed
+   * (i.e. `scheduledTime <= Date.now()`), one at a time, in order of
+   * scheduled time. Also waits for any already-in-progress functions.
    *
-   * Use in combination with `vi.useFakeTimers()` and `vi.runAllTimers()`
-   * to control precisely the execution of scheduled functions.
+   * Use in combination with `vi.useFakeTimers()` and
+   * `vi.advanceTimersByTime(ms)` to control the execution of scheduled
+   * functions.
    *
    * Typically:
-   * 1. Use `vi.runAllTimers()` or similar to advance
-   *   time such that a function is scheduled.
-   * 2. Use `finishInProgressScheduledFunctions()` to wait for the function
+   * 1. Use `vi.advanceTimersByTime(ms)` to advance time past when a
+   *    function is scheduled.
+   * 2. Use `finishInProgressScheduledFunctions()` to run and wait for
+   *    those functions.
    */
   finishInProgressScheduledFunctions: () => Promise<void>;
 
   /**
-   * Wait for all currently scheduled functions and any functions they
-   * schedule to either finish successfully or fail.
+   * Run all currently pending scheduled functions and any functions they
+   * schedule, advancing time as needed.
+   *
+   * Functions are executed one at a time in order of scheduled time.
+   * Time is advanced to each function's scheduled time before executing it.
    *
    * Use in combination with `vi.useFakeTimers()` to test scheduled functions.
    *
-   * @param advanceTimers Function that advances timers,
-   *   usually `vi.runAllTimers`. This function will be called in a loop
-   *   with `finishInProgressScheduledFunctions()`.
+   * @param advanceTimers Function that advances timers, e.g.
+   *   `vi.advanceTimersByTime` or `vi.runAllTimers`.
    */
-  finishAllScheduledFunctions: (advanceTimers: () => void) => Promise<void>;
+  finishAllScheduledFunctions: (
+    advanceTimers: (() => void) | ((ms: number) => void),
+  ) => Promise<void>;
 };
 
 export type TestConvexForDataModelAndIdentity<
@@ -2066,6 +2156,11 @@ type ConvexGlobal = {
   syscall: (op: string, args: any) => any;
   asyncSyscall: (op: string, args: any) => Promise<any>;
   jsSyscall: (op: string, args: any) => Promise<any>;
+  // Maps "sourceComponentPath:jobId" to their resolved target function paths.
+  // Needed because function handles may resolve to a different component
+  // than the one where the job is stored. Keyed by component+jobId since
+  // different components can generate the same document IDs.
+  scheduledFunctionPaths: Map<string, FunctionPath>;
 };
 
 function getConvexGlobal(): ConvexGlobal {
@@ -2291,6 +2386,7 @@ export function convexTest<Schema extends GenericSchema>(
     syscall: syscallImpl(),
     asyncSyscall: asyncSyscallImpl(),
     jsSyscall: jsSyscallImpl(),
+    scheduledFunctionPaths: new Map(),
   };
   ensureGlobalProxy();
 
@@ -2790,38 +2886,54 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
       return response;
     },
 
-    // This is needed because when we execute functions
-    // we are performing dynamic `import`s, and those
-    // are real work that cannot be force-awaited.
     finishInProgressScheduledFunctions: async (): Promise<void> => {
+      const convexGlobal = getConvexGlobal();
+      // Run any pending functions whose scheduled time has passed.
+      await runReadyScheduledFunctions(convexGlobal);
+      // Wait for any functions that are still in progress.
       await waitForInProgressScheduledFunctions();
     },
 
     finishAllScheduledFunctions: async (
-      advanceTimers: () => void,
+      advanceTimers: (() => void) | ((ms: number) => void),
       maxIterations: number = 100,
     ): Promise<void> => {
-      // Wait for all scheduled functions to finish, advancing time in between
-      // each function.
-      // Stop after a fixed number of iterations to avoid infinite loops.
+      const convexGlobal = getConvexGlobal();
+      // Run scheduled functions one at a time, advancing time to each
+      // function's scheduledTime. Stop after a fixed number of iterations
+      // to detect infinitely recursive schedules.
       for (let i = 0; i < maxIterations; i++) {
-        advanceTimers();
-        // Actions may use setTimeout internally (e.g. for delays).
-        // Keep advancing timers while waiting so those can resolve.
+        const next = await findEarliestPendingFunction(convexGlobal);
+        if (next === null) {
+          return;
+        }
+        const delta = Math.max(0, next.scheduledTime - Date.now());
+        if (delta > 0) {
+          // Create a setTimeout marker so that advanceTimers (whether
+          // vi.runAllTimers or vi.advanceTimersByTime) advances the
+          // clock to the scheduled function's time.
+          setTimeout(() => {}, delta);
+          advanceTimers(delta);
+        }
+        // Execute the function while pumping timers so that any internal
+        // setTimeout calls (e.g. in actions) can resolve. This is safe
+        // because scheduled functions are no longer triggered by setTimeout,
+        // so only the executing function's internal timers will fire.
         let done = false;
-        const waitPromise = waitForInProgressScheduledFunctions().then(
-          (had) => {
-            done = true;
-            return had;
-          },
-        );
+        const executionPromise = executeScheduledFunction(
+          convexGlobal,
+          next.componentPath,
+          next.jobId,
+        ).then(() => {
+          done = true;
+        });
         const maxPumps = 10000;
         for (let pump = 0; pump < maxPumps && !done; pump++) {
-          advanceTimers();
+          // Create a 1ms marker and advance to fire any pending timers.
+          setTimeout(() => {}, 1);
+          advanceTimers(1);
           // Yield through a full event loop iteration so that dynamic
           // import() calls (used to load function modules) can resolve.
-          // Using MessageChannel to post to the macrotask queue —
-          // it is not faked by vitest and not removed by edge-runtime.
           await new Promise<void>((r) => {
             const { port1, port2 } = new MessageChannel();
             port2.onmessage = () => r();
@@ -2835,10 +2947,7 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
             );
           }
         }
-        const hadScheduledFunctions = await waitPromise;
-        if (!hadScheduledFunctions) {
-          return;
-        }
+        await executionPromise;
       }
       throw new Error(
         "finishAllScheduledFunctions: too many iterations. " +


### PR DESCRIPTION
## Refactor scheduled function execution to use explicit scheduling instead of setTimeout

This change replaces the setTimeout-based scheduled function execution with an explicit scheduling system to reduce races from setTimeout.

Currently, scheduled functions can execute mid-transaction, especially if you don't mock timers.

**Key Changes:**

- **Explicit execution control**: Scheduled functions are no longer automatically executed via setTimeout. Instead, they are executed explicitly through `finishInProgressScheduledFunctions()` and `finishAllScheduledFunctions()`
- **Function path resolution**: Added `scheduledFunctionPaths` map to track resolved function paths for function handles that may target different components than where the job is stored.
- **Improved timer compatibility**: Adds an empty empty `setTimeout` call at the scheduled function time so `vi.runAllTimers()` still works to fast-forward time until all scheduled functions should be enqueued.
- **Sequential execution**: Functions are now executed one at a time in order of scheduled time, instead of previously where setTimeout could fire mid-transaction.

