### PR TITLE
proxy globals to isolate them between tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.0.57
+## Unreleased
 
 - Queries and mutations now throw when calling `fetch`, `setTimeout`,
   `clearTimeout`, `setInterval`, or `clearInterval`. These restrictions also apply
@@ -8,6 +8,9 @@
   fetches data or waits on timers into the test body before calling these methods.
   Use actions for application code that needs these APIs; scheduling through
   `ctx.scheduler` remains supported.
+
+## 0.0.57
+
 - Reject function `args` validators that aren't an object or `v.any()`, matching
   the error the real backend raises at push time. Previously e.g. a top-level
   `v.union(...)` args validator worked in tests but failed to deploy. (#138)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 0.0.57
 
+- Queries and mutations now throw when calling `fetch`, `setTimeout`,
+  `clearTimeout`, `setInterval`, or `clearInterval`. These restrictions also apply
+  to `t.run` and inline `t.query` / `t.mutation` callbacks. Move test setup that
+  fetches data or waits on timers into the test body before calling these methods.
+  Use actions for application code that needs these APIs; scheduling through
+  `ctx.scheduler` remains supported.
 - Reject function `args` validators that aren't an object or `v.any()`, matching
   the error the real backend raises at push time. Previously e.g. a top-level
   `v.union(...)` args validator worked in tests but failed to deploy. (#138)

--- a/README.md
+++ b/README.md
@@ -5,3 +5,13 @@ the Convex backend in TypeScript, for use in automated tests of Convex
 functions.
 
 Check out the Convex testing docs: https://docs.convex.dev/functions/testing
+
+Assignments to supported runtime globals, including `Math`, `Date`, `console`,
+`process`, and `crypto`, are isolated per Convex function invocation. Nested
+function calls see their own globals. To hide a global within a handler, assign
+`undefined`. Deleting or redefining global properties, or mutating shared objects
+in place (such as assigning `Math.random`), bypasses this isolation.
+
+Queries and mutations reject `fetch` and timer functions such as `setTimeout`.
+Use an action for those operations; scheduling through `ctx.scheduler` remains
+supported.

--- a/README.md
+++ b/README.md
@@ -15,3 +15,8 @@ in place (such as assigning `Math.random`), bypasses this isolation.
 Queries and mutations reject `fetch` and timer functions such as `setTimeout`.
 Use an action for those operations; scheduling through `ctx.scheduler` remains
 supported.
+
+Migration note: these restrictions also apply to `t.run` and inline `t.mutation`
+callbacks, which run in transactions. Tests that previously fetched data or waited
+on timers inside these callbacks must move that setup into the test body before
+calling `t.run` or `t.mutation`.

--- a/README.md
+++ b/README.md
@@ -4,19 +4,4 @@ The `convex-test` library provides a community-maintained mock implementation of
 the Convex backend in TypeScript, for use in automated tests of Convex
 functions.
 
-Check out the Convex testing docs: https://docs.convex.dev/functions/testing
-
-Assignments to supported runtime globals, including `Math`, `Date`, `console`,
-`process`, and `crypto`, are isolated per Convex function invocation. Nested
-function calls see their own globals. To hide a global within a handler, assign
-`undefined`. Deleting or redefining global properties, or mutating shared objects
-in place (such as assigning `Math.random`), bypasses this isolation.
-
-Queries and mutations reject `fetch` and timer functions such as `setTimeout`.
-Use an action for those operations; scheduling through `ctx.scheduler` remains
-supported.
-
-Migration note: these restrictions also apply to `t.run` and inline `t.mutation`
-callbacks, which run in transactions. Tests that previously fetched data or waited
-on timers inside these callbacks must move that setup into the test body before
-calling `t.run` or `t.mutation`.
+Check out the Convex testing docs: https://docs.convex.dev/testing/convex-test

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -15,6 +15,7 @@ import type * as component from "../component.js";
 import type * as convexError from "../convexError.js";
 import type * as explicitTableNames from "../explicitTableNames.js";
 import type * as getFunctionMetadata from "../getFunctionMetadata.js";
+import type * as globals from "../globals.js";
 import type * as helpers from "../helpers.js";
 import type * as http from "../http.js";
 import type * as messages from "../messages.js";
@@ -42,6 +43,7 @@ declare const fullApi: ApiFromModules<{
   convexError: typeof convexError;
   explicitTableNames: typeof explicitTableNames;
   getFunctionMetadata: typeof getFunctionMetadata;
+  globals: typeof globals;
   helpers: typeof helpers;
   http: typeof http;
   messages: typeof messages;

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -19,6 +19,7 @@ import type * as explicitTableNames from "../explicitTableNames.js";
 import type * as getDeploymentMetadata from "../getDeploymentMetadata.js";
 import type * as getFunctionMetadata from "../getFunctionMetadata.js";
 import type * as getSnapshotTs from "../getSnapshotTs.js";
+import type * as globals from "../globals.js";
 import type * as helpers from "../helpers.js";
 import type * as http from "../http.js";
 import type * as messages from "../messages.js";
@@ -50,6 +51,7 @@ declare const fullApi: ApiFromModules<{
   getDeploymentMetadata: typeof getDeploymentMetadata;
   getFunctionMetadata: typeof getFunctionMetadata;
   getSnapshotTs: typeof getSnapshotTs;
+  globals: typeof globals;
   helpers: typeof helpers;
   http: typeof http;
   messages: typeof messages;

--- a/convex/globalDescriptors.test.ts
+++ b/convex/globalDescriptors.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "vitest";
+import { convexTest } from "../index";
+import schema from "./schema";
+
+// Keep this in its own file so no earlier test has installed the global proxies.
+test("initializing convexTest preserves global property enumerability", () => {
+  const before = Object.fromEntries(
+    Object.entries(Object.getOwnPropertyDescriptors(globalThis)).map(
+      ([key, descriptor]) => [key, descriptor.enumerable],
+    ),
+  );
+
+  convexTest(schema);
+
+  const after = Object.fromEntries(
+    Object.keys(before).map((key) => [
+      key,
+      Object.getOwnPropertyDescriptor(globalThis, key)?.enumerable,
+    ]),
+  );
+  expect(after).toEqual(before);
+});

--- a/convex/globals.test.ts
+++ b/convex/globals.test.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "vitest";
+import { convexTest } from "../index";
+import { internal } from "./_generated/api";
+import schema from "./schema";
+
+test("mutation: nested query sees real globals, not patched ones", async () => {
+  const t = convexTest(schema);
+  const result = await t.mutation(internal.globals.mutationPatchingGlobal);
+  // Handler sees its own patch
+  expect(result.before).toBe("patched-by-mutation");
+  // Nested query sees real atob
+  expect(result.nested).toBe("hello");
+  // After nested call, patch is restored
+  expect(result.after).toBe("patched-by-mutation");
+});
+
+test("action: nested mutation sees real globals, not patched ones", async () => {
+  const t = convexTest(schema);
+  const result = await t.action(internal.globals.actionPatchingGlobal);
+  expect(result.before).toBe("patched-by-action");
+  expect(result.nested).toBe("hello");
+  expect(result.after).toBe("patched-by-action");
+});
+
+test("nested action gets its own global context", async () => {
+  const t = convexTest(schema);
+  const result = await t.action(internal.globals.actionPatchingGlobalNested);
+  // Outer sees its own patch before and after
+  expect(result.outerBefore).toBe("patched-by-outer");
+  expect(result.outerAfter).toBe("patched-by-outer");
+  // Inner starts with real atob, then patches its own
+  expect(result.inner.before).toBe("hello");
+  expect(result.inner.after).toBe("patched-by-inner");
+});
+
+test("parallel actions have isolated globals", async () => {
+  const t = convexTest(schema);
+  const [resultA, resultB] = await Promise.all([
+    t.action(internal.globals.actionPatchA, { delayMs: 10 }),
+    t.action(internal.globals.actionPatchB, { delayMs: 10 }),
+  ]);
+  // Each action should see only its own patch
+  expect(resultA).toBe("patched-A");
+  expect(resultB).toBe("patched-B");
+});
+
+test("globals are clean after handler that patched them", async () => {
+  const t = convexTest(schema);
+  // First, run an action that patches atob
+  await t.action(internal.globals.actionPatchingGlobal);
+  // Then run a fresh action — it should see the real atob
+  const result = await t.action(internal.globals.readAtobAction);
+  expect(result).toBe("hello");
+});
+
+test("inline mutation: patched globals restored after nested query", async () => {
+  const t = convexTest(schema);
+  await t.run(async (ctx) => {
+    await ctx.db.insert("messages", { author: "test", body: "hi" });
+  });
+
+  const result = await t.mutation(async (ctx) => {
+    (globalThis as any).atob = () => "patched-inline";
+    const before = globalThis.atob("ignored");
+    const docs = await ctx.db.query("messages").collect();
+    const after = globalThis.atob("ignored");
+    return { before, after, count: docs.length };
+  });
+
+  expect(result.before).toBe("patched-inline");
+  // atob should still be patched after the db query (same handler context)
+  expect(result.after).toBe("patched-inline");
+  expect(result.count).toBe(1);
+});

--- a/convex/globals.test.ts
+++ b/convex/globals.test.ts
@@ -53,6 +53,55 @@ test("globals are clean after handler that patched them", async () => {
   expect(result).toBe("hello");
 });
 
+test("query: fetch is not supported", async () => {
+  const t = convexTest(schema);
+  await expect(t.query(internal.globals.queryUsingFetch)).rejects.toThrow(
+    /`fetch` is not supported/,
+  );
+});
+
+test("mutation: fetch is not supported", async () => {
+  const t = convexTest(schema);
+  await expect(t.mutation(internal.globals.mutationUsingFetch)).rejects.toThrow(
+    /`fetch` is not supported/,
+  );
+});
+
+test("mutation: setTimeout is not supported", async () => {
+  const t = convexTest(schema);
+  await expect(
+    t.mutation(internal.globals.mutationUsingSetTimeout),
+  ).rejects.toThrow(/`setTimeout` is not supported/);
+});
+
+test("query: setInterval is not supported", async () => {
+  const t = convexTest(schema);
+  await expect(t.query(internal.globals.queryUsingSetInterval)).rejects.toThrow(
+    /`setInterval` is not supported/,
+  );
+});
+
+test("inline mutation via t.run: fetch is not supported", async () => {
+  const t = convexTest(schema);
+  await expect(
+    t.run(async () => {
+      await fetch("https://example.com");
+    }),
+  ).rejects.toThrow(/`fetch` is not supported/);
+});
+
+test("mutation can override the disallowed fetch sentinel", async () => {
+  const t = convexTest(schema);
+  const result = await t.mutation(internal.globals.mutationOverridingFetch);
+  expect(result).toBe('{"ok":true}');
+});
+
+test("action: setTimeout still works", async () => {
+  const t = convexTest(schema);
+  const result = await t.action(internal.globals.actionUsingSetTimeout);
+  expect(result).toBe("ok");
+});
+
 test("inline mutation: patched globals restored after nested query", async () => {
   const t = convexTest(schema);
   await t.run(async (ctx) => {

--- a/convex/globals.test.ts
+++ b/convex/globals.test.ts
@@ -160,7 +160,7 @@ test("action: setTimeout still works", async () => {
   expect(result).toBe("ok");
 });
 
-test("inline mutation: patched globals restored after nested query", async () => {
+test("inline mutation: patches persist across DB reads and are cleaned up afterward", async () => {
   const t = convexTest(schema);
   await t.run(async (ctx) => {
     await ctx.db.insert("messages", { author: "test", body: "hi" });
@@ -178,4 +178,5 @@ test("inline mutation: patched globals restored after nested query", async () =>
   // atob should still be patched after the db query (same handler context)
   expect(result.after).toBe("patched-inline");
   expect(result.count).toBe(1);
+  expect(await t.mutation(async () => atob("aGVsbG8="))).toBe("hello");
 });

--- a/convex/globals.test.ts
+++ b/convex/globals.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "vitest";
 import { convexTest } from "../index";
-import { internal } from "./_generated/api";
+import { api, internal } from "./_generated/api";
 import schema from "./schema";
 
 test("mutation: nested query sees real globals, not patched ones", async () => {
@@ -13,6 +13,64 @@ test("mutation: nested query sees real globals, not patched ones", async () => {
   // After nested call, patch is restored
   expect(result.after).toBe("patched-by-mutation");
 });
+
+test("nested mutations do not consume the caller's random sequence", async () => {
+  const t = convexTest(schema);
+  const sample = (runNested: boolean) =>
+    t.mutation(async (ctx) => {
+      const originalMath = Math;
+      const patchedMath: Math = Object.create(originalMath);
+      let draws = 0;
+      patchedMath.random = () => ++draws / 10;
+      globalThis.Math = patchedMath;
+      try {
+        const before = Math.random();
+        if (runNested) {
+          await ctx.runMutation(internal.globals.consumeRandom);
+        }
+        return [before, Math.random()];
+      } finally {
+        globalThis.Math = originalMath;
+      }
+    });
+
+  // Replaying a recorded child result must not change the caller's sequence.
+  expect(await sample(true)).toEqual([0.1, 0.2]);
+  expect(await sample(false)).toEqual([0.1, 0.2]);
+});
+
+test.each(["process", "Crypto", "crypto", "CryptoKey", "SubtleCrypto"])(
+  "assigning undefined to %s is isolated from nested calls and the test",
+  async (name) => {
+    const t = convexTest(schema);
+    const globals = globalThis as Record<string, unknown>;
+    const original = globals[name];
+    expect(original).toBeDefined();
+    const originalType = await t.query(internal.globals.readGlobalType, {
+      name,
+    });
+    try {
+      const result = await t.mutation(async (ctx) => {
+        globals[name] = undefined;
+        const before = typeof globals[name];
+        const nested = await ctx.runQuery(internal.globals.readGlobalType, {
+          name,
+        });
+        return { before, nested, after: typeof globals[name] };
+      });
+
+      expect(globals[name] === original).toBe(true);
+      expect(result).toEqual({
+        before: "undefined",
+        nested: originalType,
+        after: "undefined",
+      });
+    } finally {
+      // Keep the runner usable even when isolation regresses for process.
+      globals[name] = original;
+    }
+  },
+);
 
 test("action: nested mutation sees real globals, not patched ones", async () => {
   const t = convexTest(schema);
@@ -36,8 +94,8 @@ test("nested action gets its own global context", async () => {
 test("parallel actions have isolated globals", async () => {
   const t = convexTest(schema);
   const [resultA, resultB] = await Promise.all([
-    t.action(internal.globals.actionPatchA, { delayMs: 10 }),
-    t.action(internal.globals.actionPatchB, { delayMs: 10 }),
+    t.action(api.globals.actionPatchA, { delayMs: 10 }),
+    t.action(api.globals.actionPatchB, { delayMs: 10 }),
   ]);
   // Each action should see only its own patch
   expect(resultA).toBe("patched-A");

--- a/convex/globals.test.ts
+++ b/convex/globals.test.ts
@@ -39,6 +39,31 @@ test("nested mutations do not consume the caller's random sequence", async () =>
   expect(await sample(false)).toEqual([0.1, 0.2]);
 });
 
+test.each(["action", "inline action", "run"])(
+  "nested %s does not consume the caller's random sequence",
+  async (method) => {
+    const t = convexTest(schema);
+    const result = await t.action(async (ctx) => {
+      const patchedMath: Math = Object.create(Math);
+      let draws = 0;
+      patchedMath.random = () => ++draws / 10;
+      globalThis.Math = patchedMath;
+
+      const before = Math.random();
+      if (method === "action") {
+        await ctx.runAction(internal.globals.readAtobAction);
+      } else if (method === "inline action") {
+        await t.action(async () => null);
+      } else {
+        await t.run(async () => null);
+      }
+      return [before, Math.random()];
+    });
+
+    expect(result).toEqual([0.1, 0.2]);
+  },
+);
+
 test.each(["process", "Crypto", "crypto", "CryptoKey", "SubtleCrypto"])(
   "assigning undefined to %s is isolated from nested calls and the test",
   async (name) => {

--- a/convex/globals.ts
+++ b/convex/globals.ts
@@ -11,7 +11,9 @@ import {
 // that the patch is still visible after the nested call returns.
 export const mutationPatchingGlobal = internalMutation({
   args: {},
-  handler: async (ctx) => {
+  handler: async (
+    ctx,
+  ): Promise<{ before: string; nested: string; after: string }> => {
     const original = globalThis.atob;
     // Patch atob to a sentinel
     (globalThis as any).atob = () => "patched-by-mutation";
@@ -35,7 +37,7 @@ export const mutationPatchingGlobal = internalMutation({
 
 export const readAtob = internalQuery({
   args: {},
-  handler: async () => {
+  handler: async (): Promise<string> => {
     // Call atob with a valid base64 string to see if it's real or patched
     return globalThis.atob("aGVsbG8="); // "hello"
   },
@@ -105,7 +107,7 @@ export const innerActionPatchingGlobal = internalAction({
 // Used to verify ALS isolation between parallel actions.
 export const actionPatchA = action({
   args: { delayMs: v.number() },
-  handler: async (ctx) => {
+  handler: async () => {
     (globalThis as any).atob = () => "patched-A";
 
     // Small delay so both actions overlap
@@ -118,7 +120,7 @@ export const actionPatchA = action({
 
 export const actionPatchB = action({
   args: { delayMs: v.number() },
-  handler: async (ctx) => {
+  handler: async () => {
     (globalThis as any).atob = () => "patched-B";
 
     await new Promise((r) => setTimeout(r, 10));

--- a/convex/globals.ts
+++ b/convex/globals.ts
@@ -136,3 +136,57 @@ export const readAtobAction = internalAction({
     return globalThis.atob("aGVsbG8="); // "hello"
   },
 });
+
+// Functions that attempt to use globals disallowed in transactions.
+export const queryUsingFetch = internalQuery({
+  args: {},
+  handler: async () => {
+    await fetch("https://example.com");
+    return null;
+  },
+});
+
+export const mutationUsingFetch = internalMutation({
+  args: {},
+  handler: async () => {
+    await fetch("https://example.com");
+    return null;
+  },
+});
+
+export const mutationUsingSetTimeout = internalMutation({
+  args: {},
+  handler: async () => {
+    setTimeout(() => {}, 0);
+    return null;
+  },
+});
+
+export const queryUsingSetInterval = internalQuery({
+  args: {},
+  handler: async () => {
+    setInterval(() => {}, 0);
+    return null;
+  },
+});
+
+// User-supplied fetch override should win over the disallowed sentinel.
+export const mutationOverridingFetch = internalMutation({
+  args: {},
+  handler: async () => {
+    (globalThis as any).fetch = async () =>
+      new Response(JSON.stringify({ ok: true }));
+    const res = await fetch("https://example.com");
+    return await res.text();
+  },
+});
+
+// Action that uses fetch — should still be allowed (we only restrict in
+// transactions). Hits localhost so we don't depend on the network.
+export const actionUsingSetTimeout = internalAction({
+  args: {},
+  handler: async () => {
+    await new Promise((r) => setTimeout(r, 1));
+    return "ok";
+  },
+});

--- a/convex/globals.ts
+++ b/convex/globals.ts
@@ -1,0 +1,136 @@
+import { v } from "convex/values";
+import { internal } from "./_generated/api";
+import {
+  action,
+  internalAction,
+  internalMutation,
+  internalQuery,
+} from "./_generated/server";
+
+// A mutation that patches a global, calls a nested query, then checks
+// that the patch is still visible after the nested call returns.
+export const mutationPatchingGlobal = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const original = globalThis.atob;
+    // Patch atob to a sentinel
+    (globalThis as any).atob = () => "patched-by-mutation";
+    try {
+      // atob should be patched here
+      const before = globalThis.atob("ignored");
+
+      // Nested query — should see the REAL atob, not the patched one
+      const nested = await ctx.runQuery(internal.globals.readAtob);
+
+      // After nested call, patched atob should be restored
+      const after = globalThis.atob("ignored");
+
+      return { before, nested, after };
+    } finally {
+      // Clean up just in case — though the framework should restore it.
+      (globalThis as any).atob = original;
+    }
+  },
+});
+
+export const readAtob = internalQuery({
+  args: {},
+  handler: async () => {
+    // Call atob with a valid base64 string to see if it's real or patched
+    return globalThis.atob("aGVsbG8="); // "hello"
+  },
+});
+
+// An action that patches a global, calls a nested mutation, and verifies isolation
+export const actionPatchingGlobal = internalAction({
+  args: {},
+  handler: async (ctx) => {
+    (globalThis as any).atob = () => "patched-by-action";
+
+    const before = globalThis.atob("ignored");
+
+    // Nested mutation should see real atob
+    const nested: string = await ctx.runMutation(
+      internal.globals.nestedMutationReadAtob,
+    );
+
+    // After nested call, patch should still be visible
+    const after = globalThis.atob("ignored");
+
+    return { before, nested, after };
+  },
+});
+
+export const nestedMutationReadAtob = internalMutation({
+  args: {},
+  handler: async () => {
+    return globalThis.atob("aGVsbG8="); // "hello"
+  },
+});
+
+// An action that patches a global then calls another action that also patches it
+export const actionPatchingGlobalNested = internalAction({
+  args: {},
+  handler: async (ctx) => {
+    (globalThis as any).atob = () => "patched-by-outer";
+
+    const outerBefore = globalThis.atob("ignored");
+
+    // Inner action patches atob to something else
+    const inner: { before: string; after: string } = await ctx.runAction(
+      internal.globals.innerActionPatchingGlobal,
+    );
+
+    // Outer should still see its own patch
+    const outerAfter = globalThis.atob("ignored");
+
+    return { outerBefore, inner, outerAfter };
+  },
+});
+
+export const innerActionPatchingGlobal = internalAction({
+  args: {},
+  handler: async () => {
+    // Should start with real atob (not outer's patch)
+    const before = globalThis.atob("aGVsbG8="); // "hello"
+
+    (globalThis as any).atob = () => "patched-by-inner";
+    const after = globalThis.atob("ignored");
+
+    return { before, after };
+  },
+});
+
+// Two actions that run concurrently, each patching the same global differently.
+// Used to verify ALS isolation between parallel actions.
+export const actionPatchA = action({
+  args: { delayMs: v.number() },
+  handler: async (ctx) => {
+    (globalThis as any).atob = () => "patched-A";
+
+    // Small delay so both actions overlap
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Should still see our own patch, not the other action's
+    return globalThis.atob("ignored");
+  },
+});
+
+export const actionPatchB = action({
+  args: { delayMs: v.number() },
+  handler: async (ctx) => {
+    (globalThis as any).atob = () => "patched-B";
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    return globalThis.atob("ignored");
+  },
+});
+
+// Verify globals are clean after a handler that patched them
+export const readAtobAction = internalAction({
+  args: {},
+  handler: async () => {
+    return globalThis.atob("aGVsbG8="); // "hello"
+  },
+});

--- a/convex/globals.ts
+++ b/convex/globals.ts
@@ -43,6 +43,19 @@ export const readAtob = internalQuery({
   },
 });
 
+export const consumeRandom = internalMutation({
+  args: {},
+  returns: v.number(),
+  handler: async () => Math.random(),
+});
+
+export const readGlobalType = internalQuery({
+  args: { name: v.string() },
+  returns: v.string(),
+  handler: async (_ctx, { name }) =>
+    typeof (globalThis as Record<string, unknown>)[name],
+});
+
 // An action that patches a global, calls a nested mutation, and verifies isolation
 export const actionPatchingGlobal = internalAction({
   args: {},

--- a/convex/http.test.ts
+++ b/convex/http.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "vitest";
 import { convexTest } from "../index";
+import { internal } from "./_generated/api";
 import schema from "./schema";
 
 test("simple", async () => {
@@ -32,4 +33,56 @@ test("http action runs query", async () => {
   const response = await t.fetch("/readQuery", { method: "POST" });
   const message = await response.json();
   expect(message.body).toEqual("hello");
+});
+
+test("HTTP global patches are isolated from nested calls and later handlers", async () => {
+  const t = convexTest(schema);
+  const originalAtob = globalThis.atob;
+  try {
+    const response = await t.fetch("/globals?patch=patched-http");
+    expect(await response.json()).toEqual({
+      before: "patched-http",
+      nested: "hello",
+      after: "patched-http",
+    });
+    expect(globalThis.atob).toBe(originalAtob);
+    expect(await t.query(internal.globals.readAtob)).toBe("hello");
+    expect(await (await t.fetch("/globals")).text()).toBe("hello");
+  } finally {
+    globalThis.atob = originalAtob;
+  }
+});
+
+test("HTTP global patches do not leak after a handler throws", async () => {
+  const t = convexTest(schema);
+  const originalAtob = globalThis.atob;
+  try {
+    await expect(t.fetch("/globals?patch=patched-error&throw")).rejects.toThrow(
+      "HTTP handler failed after patching globals",
+    );
+    expect(globalThis.atob).toBe(originalAtob);
+    expect(await (await t.fetch("/globals")).text()).toBe("hello");
+  } finally {
+    globalThis.atob = originalAtob;
+  }
+});
+
+test("parallel HTTP handlers have isolated globals", async () => {
+  const t = convexTest(schema);
+  const originalAtob = globalThis.atob;
+  try {
+    const responses = await Promise.all([
+      t.fetch("/globals?patch=first"),
+      t.fetch("/globals?patch=second"),
+    ]);
+    expect(
+      await Promise.all(responses.map((response) => response.json())),
+    ).toEqual([
+      { before: "first", nested: "hello", after: "first" },
+      { before: "second", nested: "hello", after: "second" },
+    ]);
+    expect(globalThis.atob).toBe(originalAtob);
+  } finally {
+    globalThis.atob = originalAtob;
+  }
 });

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -54,4 +54,23 @@ http.route({
   }),
 });
 
+http.route({
+  path: "/globals",
+  method: "GET",
+  handler: httpAction(async (ctx, request) => {
+    const url = new URL(request.url);
+    const patch = url.searchParams.get("patch");
+    if (patch === null) {
+      return new Response(atob("aGVsbG8="));
+    }
+    globalThis.atob = () => patch;
+    if (url.searchParams.has("throw")) {
+      throw new Error("HTTP handler failed after patching globals");
+    }
+    const before = atob("aGVsbG8=");
+    const nested = await ctx.runQuery(internal.globals.readAtob);
+    return Response.json({ before, nested, after: atob("aGVsbG8=") });
+  }),
+});
+
 export default http;

--- a/convex/vectorSearch.ts
+++ b/convex/vectorSearch.ts
@@ -22,7 +22,10 @@ export const vectorSearch = action({
     embedding: v.array(v.number()),
     limit: v.number(),
   },
-  handler: async (ctx, { author, embedding, limit }) => {
+  handler: async (
+    ctx,
+    { author, embedding, limit },
+  ): Promise<Array<Doc<"messages"> & { score: number }>> => {
     const results = await ctx.vectorSearch("messages", "embedding", {
       vector: embedding,
       filter: author !== null ? (q) => q.eq("author", author) : undefined,

--- a/index.ts
+++ b/index.ts
@@ -2070,6 +2070,75 @@ function getConvexGlobal(): ConvexGlobal {
   return store;
 }
 
+// Globals that libraries (e.g. workflow engines) may patch during function
+// execution. Each handler invocation gets its own AsyncLocalStorage context,
+// so patches are isolated per-context and nested Convex calls automatically
+// see the original (real) globals.
+const PATCHABLE_GLOBALS = [
+  "setTimeout",
+  "clearTimeout",
+  "setInterval",
+  "clearInterval",
+  "fetch",
+  "Date",
+  "console",
+  "crypto",
+  "atob",
+  "btoa",
+  "Request",
+  "Response",
+  "Headers",
+  "URL",
+  "URLSearchParams",
+  "AbortController",
+  "TextEncoder",
+  "TextDecoder",
+  "structuredClone",
+  "queueMicrotask",
+  "performance",
+] as const;
+
+type GlobalOverrides = Record<string, unknown>;
+const globalOverridesStorage = new AsyncLocalStorage<GlobalOverrides>();
+
+// Replace tracked globals with ALS-backed getter/setters so that writes
+// from user code land in the current context's override map while reads
+// fall through to the original value when no override exists.
+let _globalProxiesInstalled = false;
+function installGlobalProxies() {
+  if (_globalProxiesInstalled) return;
+  _globalProxiesInstalled = true;
+
+  const g = globalThis as Record<string, unknown>;
+  const originals: Record<string, unknown> = {};
+
+  for (const key of PATCHABLE_GLOBALS) {
+    if (!(key in g)) continue;
+    originals[key] = g[key];
+
+    try {
+      Object.defineProperty(g, key, {
+        get() {
+          const store = globalOverridesStorage.getStore();
+          return store && key in store ? store[key] : originals[key];
+        },
+        set(value: unknown) {
+          const store = globalOverridesStorage.getStore();
+          if (store) {
+            store[key] = value;
+          } else {
+            originals[key] = value;
+          }
+        },
+        configurable: true,
+        enumerable: true,
+      });
+    } catch {
+      // Some globals (e.g. crypto) may not be configurable.
+    }
+  }
+}
+
 // Install a permanent global proxy so the Convex runtime's
 // `Convex.syscall` / `Convex.asyncSyscall` / `Convex.jsSyscall`
 // always delegate to the current test's ALS context.
@@ -2078,6 +2147,7 @@ let _globalProxyInstalled = false;
 function ensureGlobalProxy() {
   if (_globalProxyInstalled) return;
   _globalProxyInstalled = true;
+  installGlobalProxies();
   (global as unknown as { Convex: ConvexGlobal }).Convex = {
     get syscall() {
       return getConvexGlobal().syscall;
@@ -2350,7 +2420,7 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
           auth: authStorage.getStore() ?? auth,
           ...extraCtx,
         };
-        return handler(testCtx, a);
+        return globalOverridesStorage.run({}, () => handler(testCtx, a));
       },
     });
     const transactionManager = getTransactionManager();
@@ -2400,7 +2470,7 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
     const q = queryGeneric({
       handler: (ctx: any, a: any) => {
         const testCtx = { ...ctx, auth: authStorage.getStore() ?? auth };
-        return handler(testCtx, a);
+        return globalOverridesStorage.run({}, () => handler(testCtx, a));
       },
     });
     const transactionManager = getTransactionManager();
@@ -2455,7 +2525,9 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
           runAction: ctxRunAction,
           auth: authStorage.getStore() ?? auth,
         };
-        return handler(testCtx, innerArgs);
+        return globalOverridesStorage.run({}, () =>
+          handler(testCtx, innerArgs),
+        );
       },
     });
     const authForChild = authForComponent(functionPath.componentPath);

--- a/index.ts
+++ b/index.ts
@@ -1567,7 +1567,7 @@ function asyncSyscallImpl() {
         // function callback (which runs via setTimeout, outside the
         // original ALS context) uses the correct test state.
         const capturedGlobal = getConvexGlobal();
-        setTimeout(
+        realSetTimeout(
           // Scheduled functions run without auth context, even if
           // they were scheduled from an authenticated function.
           (() =>
@@ -2101,6 +2101,41 @@ const PATCHABLE_GLOBALS = [
 type GlobalOverrides = Record<string, unknown>;
 const globalOverridesStorage = new AsyncLocalStorage<GlobalOverrides>();
 
+// The framework's own scheduler needs setTimeout even when running inside a
+// transaction context where setTimeout is disallowed for user code. Exit the
+// override store before reading globalThis.setTimeout so we get the underlying
+// value (which still honors vitest fake timers, since those replace the proxy
+// target rather than entering an ALS context).
+function realSetTimeout(
+  cb: (...args: unknown[]) => void,
+  ms?: number,
+): ReturnType<typeof setTimeout> {
+  return globalOverridesStorage.exit(() => globalThis.setTimeout(cb, ms));
+}
+
+// Globals that the real Convex runtime does not provide inside queries and
+// mutations (transactions). Reading them is fine; calling them throws. Users
+// can still assign to `globalThis.fetch` etc. inside a handler — writes land
+// in the per-call ALS override map and replace the sentinel for that call.
+function disallowedInTransaction(name: string): (...args: unknown[]) => never {
+  return () => {
+    throw new Error(
+      `\`${name}\` is not supported in Convex queries or mutations. ` +
+        `Use an action instead, or call \`ctx.runAction\` to perform side effects.`,
+    );
+  };
+}
+
+function transactionGlobalOverrides(): GlobalOverrides {
+  return {
+    fetch: disallowedInTransaction("fetch"),
+    setTimeout: disallowedInTransaction("setTimeout"),
+    clearTimeout: disallowedInTransaction("clearTimeout"),
+    setInterval: disallowedInTransaction("setInterval"),
+    clearInterval: disallowedInTransaction("clearInterval"),
+  };
+}
+
 // Replace tracked globals with ALS-backed getter/setters so that writes
 // from user code land in the current context's override map while reads
 // fall through to the original value when no override exists.
@@ -2420,7 +2455,9 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
           auth: authStorage.getStore() ?? auth,
           ...extraCtx,
         };
-        return globalOverridesStorage.run({}, () => handler(testCtx, a));
+        return globalOverridesStorage.run(transactionGlobalOverrides(), () =>
+          handler(testCtx, a),
+        );
       },
     });
     const transactionManager = getTransactionManager();
@@ -2470,7 +2507,9 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
     const q = queryGeneric({
       handler: (ctx: any, a: any) => {
         const testCtx = { ...ctx, auth: authStorage.getStore() ?? auth };
-        return globalOverridesStorage.run({}, () => handler(testCtx, a));
+        return globalOverridesStorage.run(transactionGlobalOverrides(), () =>
+          handler(testCtx, a),
+        );
       },
     });
     const transactionManager = getTransactionManager();

--- a/index.ts
+++ b/index.ts
@@ -1691,7 +1691,7 @@ function asyncSyscallImpl() {
         // rather than inheriting a stale parent lock.
         nestedTxStorage.exit(() => {
           scheduler.timerScheduled();
-          setTimeout(
+          frameworkSetTimeout(
             () => {
               scheduler.timerFired();
               // Scheduled functions run without auth context, even if
@@ -2225,6 +2225,44 @@ const PATCHABLE_GLOBALS = [
 type GlobalOverrides = Record<string, unknown>;
 const globalOverridesStorage = new AsyncLocalStorage<GlobalOverrides>();
 
+// The framework's own scheduler needs setTimeout even when running inside a
+// transaction context where setTimeout is disallowed for user code. Exit the
+// override store before reading globalThis.setTimeout so we get the underlying
+// value (which still honors vitest fake timers, since those replace the proxy
+// target rather than entering an ALS context). Registering the timer outside
+// the store also means the callback doesn't inherit the scheduling function's
+// overrides. Unlike `realSetTimeout`, this is still fake-timer aware, so
+// scheduled functions fire when a test advances timers.
+function frameworkSetTimeout(
+  cb: (...args: unknown[]) => void,
+  ms?: number,
+): ReturnType<typeof setTimeout> {
+  return globalOverridesStorage.exit(() => globalThis.setTimeout(cb, ms));
+}
+
+// Globals that the real Convex runtime does not provide inside queries and
+// mutations (transactions). Reading them is fine; calling them throws. Users
+// can still assign to `globalThis.fetch` etc. inside a handler — writes land
+// in the per-call ALS override map and replace the sentinel for that call.
+function disallowedInTransaction(name: string): (...args: unknown[]) => never {
+  return () => {
+    throw new Error(
+      `\`${name}\` is not supported in Convex queries or mutations. ` +
+        `Use an action instead, or call \`ctx.runAction\` to perform side effects.`,
+    );
+  };
+}
+
+function transactionGlobalOverrides(): GlobalOverrides {
+  return {
+    fetch: disallowedInTransaction("fetch"),
+    setTimeout: disallowedInTransaction("setTimeout"),
+    clearTimeout: disallowedInTransaction("clearTimeout"),
+    setInterval: disallowedInTransaction("setInterval"),
+    clearInterval: disallowedInTransaction("clearInterval"),
+  };
+}
+
 // Replace tracked globals with ALS-backed getter/setters so that writes
 // from user code land in the current context's override map while reads
 // fall through to the original value when no override exists.
@@ -2653,7 +2691,9 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
           auth: authStorage.getStore() ?? auth,
           ...extraCtx,
         };
-        return globalOverridesStorage.run({}, () => handler(testCtx, a));
+        return globalOverridesStorage.run(transactionGlobalOverrides(), () =>
+          handler(testCtx, a),
+        );
       },
     });
     const transactionManager = getTransactionManager();
@@ -2708,7 +2748,9 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
     const q = queryGeneric({
       handler: (ctx: any, a: any) => {
         const testCtx = { ...ctx, auth: authStorage.getStore() ?? auth };
-        return globalOverridesStorage.run({}, () => handler(testCtx, a));
+        return globalOverridesStorage.run(transactionGlobalOverrides(), () =>
+          handler(testCtx, a),
+        );
       },
     });
     const transactionManager = getTransactionManager();

--- a/index.ts
+++ b/index.ts
@@ -2197,7 +2197,9 @@ function getConvexGlobal(): ConvexGlobal {
 // Globals that libraries (e.g. workflow engines) may patch during function
 // execution. Each handler invocation gets its own AsyncLocalStorage context,
 // so patches are isolated per-context and nested Convex calls automatically
-// see the original (real) globals.
+// see the original (real) globals. Only assignments are isolated: deleting or
+// redefining a global bypasses its accessor, and mutating an object in place
+// still changes the shared object. Assign undefined to hide a global instead.
 const PATCHABLE_GLOBALS = [
   "setTimeout",
   "clearTimeout",
@@ -2205,8 +2207,13 @@ const PATCHABLE_GLOBALS = [
   "clearInterval",
   "fetch",
   "Date",
+  "Math",
   "console",
+  "process",
   "crypto",
+  "Crypto",
+  "CryptoKey",
+  "SubtleCrypto",
   "atob",
   "btoa",
   "Request",

--- a/index.ts
+++ b/index.ts
@@ -1978,6 +1978,9 @@ export type TestConvexForDataModel<DataModel extends GenericDataModel> = {
   /**
    * Read from and write to the mock backend.
    *
+   * The callback runs in a transaction, so `fetch` and timers are unavailable.
+   * Perform setup that needs them in the test body before calling `run`.
+   *
    * @param func The async function that reads or writes to the mock backend.
    *   It receives a ctx as its first argument that conforms to
    *   {@link GenericMutationCtx},
@@ -2284,6 +2287,7 @@ function installGlobalProxies() {
 
   for (const key of PATCHABLE_GLOBALS) {
     if (!(key in g)) continue;
+    const descriptor = Object.getOwnPropertyDescriptor(g, key);
     originals[key] = g[key];
 
     try {
@@ -2301,7 +2305,7 @@ function installGlobalProxies() {
           }
         },
         configurable: true,
-        enumerable: true,
+        enumerable: descriptor?.enumerable ?? false,
       });
     } catch {
       // Some globals (e.g. crypto) may not be configurable.

--- a/index.ts
+++ b/index.ts
@@ -2697,6 +2697,10 @@ function yieldThroughRealTimers(): Promise<void> {
   return new Promise<void>((r) => realSetTimeout(r, 0));
 }
 
+// Request IDs are internal bookkeeping. Generating them must not consume a
+// handler's mocked Math.random sequence. The prefix marks these as test-only IDs.
+let nextRequestId = 0;
+
 function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
   // Auth doesn't propagate across component boundaries.
   function authForComponent(componentPath: string) {
@@ -2857,7 +2861,7 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
       paginatedQueries: 0,
     };
     return await executionContextStorage.run(childCtx, async () => {
-      const requestId = "" + Math.random();
+      const requestId = `fake-request-id-${nextRequestId++}`;
       try {
         const rawResult = await authStorage.run(authForChild, () =>
           (
@@ -3133,8 +3137,7 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
         );
       },
     });
-    // Real backend uses different ID format
-    const requestId = "" + Math.random();
+    const requestId = `fake-request-id-${nextRequestId++}`;
     try {
       const rawResult = await (
         a as unknown as {

--- a/index.ts
+++ b/index.ts
@@ -2194,6 +2194,75 @@ function getConvexGlobal(): ConvexGlobal {
   return store;
 }
 
+// Globals that libraries (e.g. workflow engines) may patch during function
+// execution. Each handler invocation gets its own AsyncLocalStorage context,
+// so patches are isolated per-context and nested Convex calls automatically
+// see the original (real) globals.
+const PATCHABLE_GLOBALS = [
+  "setTimeout",
+  "clearTimeout",
+  "setInterval",
+  "clearInterval",
+  "fetch",
+  "Date",
+  "console",
+  "crypto",
+  "atob",
+  "btoa",
+  "Request",
+  "Response",
+  "Headers",
+  "URL",
+  "URLSearchParams",
+  "AbortController",
+  "TextEncoder",
+  "TextDecoder",
+  "structuredClone",
+  "queueMicrotask",
+  "performance",
+] as const;
+
+type GlobalOverrides = Record<string, unknown>;
+const globalOverridesStorage = new AsyncLocalStorage<GlobalOverrides>();
+
+// Replace tracked globals with ALS-backed getter/setters so that writes
+// from user code land in the current context's override map while reads
+// fall through to the original value when no override exists.
+let _globalProxiesInstalled = false;
+function installGlobalProxies() {
+  if (_globalProxiesInstalled) return;
+  _globalProxiesInstalled = true;
+
+  const g = globalThis as Record<string, unknown>;
+  const originals: Record<string, unknown> = {};
+
+  for (const key of PATCHABLE_GLOBALS) {
+    if (!(key in g)) continue;
+    originals[key] = g[key];
+
+    try {
+      Object.defineProperty(g, key, {
+        get() {
+          const store = globalOverridesStorage.getStore();
+          return store && key in store ? store[key] : originals[key];
+        },
+        set(value: unknown) {
+          const store = globalOverridesStorage.getStore();
+          if (store) {
+            store[key] = value;
+          } else {
+            originals[key] = value;
+          }
+        },
+        configurable: true,
+        enumerable: true,
+      });
+    } catch {
+      // Some globals (e.g. crypto) may not be configurable.
+    }
+  }
+}
+
 // Install a permanent global proxy so the Convex runtime's
 // `Convex.syscall` / `Convex.asyncSyscall` / `Convex.jsSyscall`
 // always delegate to the current test's ALS context.
@@ -2202,6 +2271,7 @@ let _globalProxyInstalled = false;
 function ensureGlobalProxy() {
   if (_globalProxyInstalled) return;
   _globalProxyInstalled = true;
+  installGlobalProxies();
   (global as unknown as { Convex: ConvexGlobal }).Convex = {
     get syscall() {
       return getConvexGlobal().syscall;
@@ -2583,7 +2653,7 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
           auth: authStorage.getStore() ?? auth,
           ...extraCtx,
         };
-        return handler(testCtx, a);
+        return globalOverridesStorage.run({}, () => handler(testCtx, a));
       },
     });
     const transactionManager = getTransactionManager();
@@ -2638,7 +2708,7 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
     const q = queryGeneric({
       handler: (ctx: any, a: any) => {
         const testCtx = { ...ctx, auth: authStorage.getStore() ?? auth };
-        return handler(testCtx, a);
+        return globalOverridesStorage.run({}, () => handler(testCtx, a));
       },
     });
     const transactionManager = getTransactionManager();
@@ -2701,7 +2771,9 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
           runAction: ctxRunAction,
           auth: authStorage.getStore() ?? auth,
         };
-        return handler(testCtx, innerArgs);
+        return globalOverridesStorage.run({}, () =>
+          handler(testCtx, innerArgs),
+        );
       },
     });
     const authForChild = authForComponent(functionPath.componentPath);

--- a/index.ts
+++ b/index.ts
@@ -3167,7 +3167,9 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
           runAction: byType.action,
           auth,
         };
-        return getHandler(func)(testCtx, a);
+        return globalOverridesStorage.run({}, () =>
+          getHandler(func)(testCtx, a),
+        );
       });
       const httpCtx: ExecutionContext = {
         componentPath: getCurrentComponentPath(),

--- a/index.ts
+++ b/index.ts
@@ -2248,7 +2248,8 @@ function disallowedInTransaction(name: string): (...args: unknown[]) => never {
   return () => {
     throw new Error(
       `\`${name}\` is not supported in Convex queries or mutations. ` +
-        `Use an action instead, or call \`ctx.runAction\` to perform side effects.`,
+        `Move this code to an action; a mutation can start one with ` +
+        `\`ctx.scheduler.runAfter(0, ...)\`.`,
     );
   };
 }

--- a/index.ts
+++ b/index.ts
@@ -2197,12 +2197,30 @@ function getConvexGlobal(): ConvexGlobal {
   return store;
 }
 
-// Globals that libraries (e.g. workflow engines) may patch during function
-// execution. Each handler invocation gets its own AsyncLocalStorage context,
-// so patches are isolated per-context and nested Convex calls automatically
-// see the original (real) globals. Only assignments are isolated: deleting or
-// redefining a global bypasses its accessor, and mutating an object in place
-// still changes the shared object. Assign undefined to hide a global instead.
+/*
+ * Globals that libraries (e.g. workflow engines) may override during a handler.
+ * Each invocation gets its own AsyncLocalStorage context. Nested Convex calls
+ * start from the test environment's globals, with their own runtime restrictions,
+ * instead of inheriting the caller's overrides.
+ *
+ * Known limitation: isolation relies on the getters/setters installed below:
+ * ✅ `globalThis.Math = replacement` calls the setter, isolating the replacement.
+ * ❌ `delete globalThis.crypto` removes the getter/setter entirely.
+ * ❌ `Object.defineProperty(globalThis, "Math", { value: replacement })` replaces
+ *    the getter/setter without calling it, changing the global for all handlers.
+ * ❌ `Math.random = replacement` changes a property of the shared Math object,
+ *    without calling the setter for globalThis.Math.
+ *
+ * Replacing an accessor bypasses isolation and runtime restrictions even when
+ * done in test setup before calling a handler. For example, vi.stubGlobal uses
+ * Object.defineProperty, so it also bypasses them when called after installation.
+ *
+ * To work around this limitation, assign a replacement object to the global.
+ * To make a global's value unavailable, assign undefined instead of using delete
+ * (the property will still exist). Only the globals listed below that are present
+ * and configurable in the test environment can be isolated. Assignments outside
+ * handlers change the shared test environment and must be restored by the test.
+ */
 const PATCHABLE_GLOBALS = [
   "setTimeout",
   "clearTimeout",


### PR DESCRIPTION
## Proxy globals to isolate them between tests

Added global proxy system using AsyncLocalStorage to isolate global variable modifications between test contexts. When user code patches globals like `setTimeout`, `fetch`, `Date`, etc., the changes are scoped to the current handler execution and don't leak to nested Convex calls or parallel executions.

The proxy intercepts reads/writes to a predefined list of patchable globals, storing overrides in per-context storage while falling back to original values when no override exists.

Added comprehensive test coverage for global isolation scenarios including nested queries/mutations, parallel actions, and inline handlers.