### PR TITLE
Implement ctx.meta syscalls

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -13,9 +13,11 @@ import type * as argumentsValidation from "../argumentsValidation.js";
 import type * as authentication from "../authentication.js";
 import type * as component from "../component.js";
 import type * as explicitTableNames from "../explicitTableNames.js";
+import type * as getFunctionMetadata from "../getFunctionMetadata.js";
 import type * as helpers from "../helpers.js";
 import type * as http from "../http.js";
 import type * as messages from "../messages.js";
+import type * as meta from "../meta.js";
 import type * as mutations from "../mutations.js";
 import type * as pagination from "../pagination.js";
 import type * as queries from "../queries.js";
@@ -37,9 +39,11 @@ declare const fullApi: ApiFromModules<{
   authentication: typeof authentication;
   component: typeof component;
   explicitTableNames: typeof explicitTableNames;
+  getFunctionMetadata: typeof getFunctionMetadata;
   helpers: typeof helpers;
   http: typeof http;
   messages: typeof messages;
+  meta: typeof meta;
   mutations: typeof mutations;
   pagination: typeof pagination;
   queries: typeof queries;
@@ -100,6 +104,7 @@ export declare const components: {
       >;
       getIdentityName: FunctionReference<"query", "internal", {}, any>;
       getIdentityNameAction: FunctionReference<"action", "internal", {}, any>;
+      metadata: FunctionReference<"query", "internal", {}, any>;
       mutationWithNestedQuery: FunctionReference<
         "mutation",
         "internal",
@@ -143,6 +148,7 @@ export declare const components: {
       >;
       getIdentityName: FunctionReference<"query", "internal", {}, any>;
       getIdentityNameAction: FunctionReference<"action", "internal", {}, any>;
+      metadata: FunctionReference<"query", "internal", {}, any>;
       mutationWithNestedQuery: FunctionReference<
         "mutation",
         "internal",

--- a/convex/authentication.test.ts
+++ b/convex/authentication.test.ts
@@ -94,8 +94,13 @@ test("scheduled function does not receive auth", async () => {
   const t = convexTest(schema);
   const asSarah = t.withIdentity({ name: "Sarah" });
   // Sarah schedules a query that checks auth
-  await asSarah.mutation(api.authentication.scheduleQuery);
+  const scheduled = await asSarah.mutation(api.authentication.scheduledNoAuth);
   await t.finishAllScheduledFunctions(vi.runAllTimers);
+  const result = await t.query((ctx) =>
+    ctx.db.system.get("_scheduled_functions", scheduled),
+  );
+  expect(result?.state.kind).toBe("success");
+
   vi.useRealTimers();
   // The scheduled query should have run without auth (no error = pass).
   // queryName returns undefined when there's no identity, which is fine.

--- a/convex/authentication.ts
+++ b/convex/authentication.ts
@@ -1,4 +1,5 @@
 import { api } from "./_generated/api";
+import { type Id } from "./_generated/dataModel";
 import { action, mutation, query } from "./_generated/server";
 
 export const actionCallingQuery = action({
@@ -78,9 +79,18 @@ export const actionName = action({
   },
 });
 
-export const scheduleQuery = mutation({
+export const assertNoAuth = mutation({
   args: {},
   async handler(ctx): Promise<void> {
-    await ctx.scheduler.runAfter(0, api.authentication.queryName);
+    if (await ctx.auth.getUserIdentity()) {
+      throw new Error("Expected no auth");
+    }
+  },
+});
+
+export const scheduledNoAuth = mutation({
+  args: {},
+  async handler(ctx): Promise<Id<"_scheduled_functions">> {
+    return await ctx.scheduler.runAfter(0, api.authentication.assertNoAuth);
   },
 });

--- a/convex/bandwidth.test.ts
+++ b/convex/bandwidth.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "vitest";
+import { getDocumentSize } from "convex/values";
 import { convexTest } from "../index";
 import schema from "./schema";
 
@@ -156,23 +157,23 @@ test("getTransactionMetrics returns bandwidth stats", async () => {
     await ctx.db.insert("messages", { author: "sarah", body: "hello" });
     await ctx.db.insert("messages", { author: "michal", body: "world" });
   });
-  const consumption = await t.query(async (ctx) => {
-    await ctx.db.query("messages").collect();
+  const { consumption, totalBytes } = await t.query(async (ctx) => {
+    const docs = await ctx.db.query("messages").collect();
+    const totalBytes = docs.reduce((sum, doc) => sum + getDocumentSize(doc), 0);
     const syscalls = (global as any).Convex;
-    return JSON.parse(
+    const consumption = JSON.parse(
       await syscalls.asyncSyscall(
         "1.0/getTransactionMetrics",
         JSON.stringify({}),
       ),
     );
+    return { consumption, totalBytes };
   });
-  // Should have read some bytes and documents
-  expect(consumption.documentsRead.used).toBeGreaterThan(0);
-  expect(consumption.bytesRead.used).toBeGreaterThan(0);
-  expect(consumption.databaseQueries.used).toBeGreaterThan(0);
-  // Should have remaining capacity
-  expect(consumption.documentsRead.remaining).toBeGreaterThan(0);
-  expect(consumption.bytesRead.remaining).toBeGreaterThan(0);
+  expect(consumption.documentsRead.used).toBe(2);
+  expect(consumption.bytesRead.used).toBe(totalBytes);
+  expect(consumption.databaseQueries.used).toBe(1);
+  expect(consumption.documentsRead.remaining).toBe(32000 - 2);
+  expect(consumption.bytesRead.remaining).toBe((16 << 20) - totalBytes);
   expect(consumption.bytesWritten.used).toBe(0);
   expect(consumption.documentsWritten.used).toBe(0);
   expect(consumption.functionsScheduled.used).toBe(0);
@@ -181,16 +182,22 @@ test("getTransactionMetrics returns bandwidth stats", async () => {
 
 test("getTransactionMetrics tracks writes", async () => {
   const t = convexTest({ schema });
-  const consumption = await t.mutation(async (ctx) => {
-    await ctx.db.insert("messages", { author: "sarah", body: "hello" });
+  const { consumption, docBytes } = await t.mutation(async (ctx) => {
+    const id = await ctx.db.insert("messages", {
+      author: "sarah",
+      body: "hello",
+    });
+    const doc = (await ctx.db.get(id))!;
+    const docBytes = getDocumentSize(doc);
     const syscalls = (global as any).Convex;
-    return JSON.parse(
+    const consumption = JSON.parse(
       await syscalls.asyncSyscall(
         "1.0/getTransactionMetrics",
         JSON.stringify({}),
       ),
     );
+    return { consumption, docBytes };
   });
   expect(consumption.documentsWritten.used).toBe(1);
-  expect(consumption.bytesWritten.used).toBeGreaterThan(0);
+  expect(consumption.bytesWritten.used).toBe(docBytes);
 });

--- a/convex/bandwidth.test.ts
+++ b/convex/bandwidth.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "vitest";
 import { getDocumentSize } from "convex/values";
 import { convexTest } from "../index";
 import schema from "./schema";
+import { getTransactionMetrics } from "./meta";
 
 test("default: limits disabled, no throws", async () => {
   const t = convexTest({ schema });
@@ -160,13 +161,7 @@ test("getTransactionMetrics returns bandwidth stats", async () => {
   const { consumption, totalBytes } = await t.query(async (ctx) => {
     const docs = await ctx.db.query("messages").collect();
     const totalBytes = docs.reduce((sum, doc) => sum + getDocumentSize(doc), 0);
-    const syscalls = (global as any).Convex;
-    const consumption = JSON.parse(
-      await syscalls.asyncSyscall(
-        "1.0/getTransactionMetrics",
-        JSON.stringify({}),
-      ),
-    );
+    const consumption = await getTransactionMetrics();
     return { consumption, totalBytes };
   });
   expect(consumption.documentsRead.used).toBe(2);
@@ -189,13 +184,7 @@ test("getTransactionMetrics tracks writes", async () => {
     });
     const doc = (await ctx.db.get(id))!;
     const docBytes = getDocumentSize(doc);
-    const syscalls = (global as any).Convex;
-    const consumption = JSON.parse(
-      await syscalls.asyncSyscall(
-        "1.0/getTransactionMetrics",
-        JSON.stringify({}),
-      ),
-    );
+    const consumption = await getTransactionMetrics();
     return { consumption, docBytes };
   });
   expect(consumption.documentsWritten.used).toBe(1);

--- a/convex/bandwidth.test.ts
+++ b/convex/bandwidth.test.ts
@@ -150,7 +150,7 @@ test("limits accumulate within a transaction", async () => {
   ).rejects.toThrow(/Scanned too many documents/);
 });
 
-test("getTransactionHeadroom returns bandwidth stats", async () => {
+test("getTransactionMetrics returns bandwidth stats", async () => {
   const t = convexTest({ schema });
   await t.run(async (ctx) => {
     await ctx.db.insert("messages", { author: "sarah", body: "hello" });
@@ -158,14 +158,39 @@ test("getTransactionHeadroom returns bandwidth stats", async () => {
   });
   const consumption = await t.query(async (ctx) => {
     await ctx.db.query("messages").collect();
-    // TODO: replace with getTransactionHeadroom() once it's published
     const syscalls = (global as any).Convex;
     return JSON.parse(
-      await syscalls.asyncSyscall("1.0/headroom", JSON.stringify({})),
+      await syscalls.asyncSyscall(
+        "1.0/getTransactionMetrics",
+        JSON.stringify({}),
+      ),
     );
   });
   // Should have read some bytes and documents
   expect(consumption.documentsRead.used).toBeGreaterThan(0);
   expect(consumption.bytesRead.used).toBeGreaterThan(0);
   expect(consumption.databaseQueries.used).toBeGreaterThan(0);
+  // Should have remaining capacity
+  expect(consumption.documentsRead.remaining).toBeGreaterThan(0);
+  expect(consumption.bytesRead.remaining).toBeGreaterThan(0);
+  expect(consumption.bytesWritten.used).toBe(0);
+  expect(consumption.documentsWritten.used).toBe(0);
+  expect(consumption.functionsScheduled.used).toBe(0);
+  expect(consumption.scheduledFunctionArgsBytes.used).toBe(0);
+});
+
+test("getTransactionMetrics tracks writes", async () => {
+  const t = convexTest({ schema });
+  const consumption = await t.mutation(async (ctx) => {
+    await ctx.db.insert("messages", { author: "sarah", body: "hello" });
+    const syscalls = (global as any).Convex;
+    return JSON.parse(
+      await syscalls.asyncSyscall(
+        "1.0/getTransactionMetrics",
+        JSON.stringify({}),
+      ),
+    );
+  });
+  expect(consumption.documentsWritten.used).toBe(1);
+  expect(consumption.bytesWritten.used).toBeGreaterThan(0);
 });

--- a/convex/counter/component/_generated/component.ts
+++ b/convex/counter/component/_generated/component.ts
@@ -38,6 +38,13 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         number,
         Name
       >;
+      countAction: FunctionReference<
+        "action",
+        "internal",
+        { name: string },
+        number,
+        Name
+      >;
       countMany: FunctionReference<
         "action",
         "internal",
@@ -45,6 +52,15 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         Array<number>,
         Name
       >;
+      getIdentityName: FunctionReference<"query", "internal", {}, any, Name>;
+      getIdentityNameAction: FunctionReference<
+        "action",
+        "internal",
+        {},
+        any,
+        Name
+      >;
+      metadata: FunctionReference<"query", "internal", {}, any, Name>;
       mutationWithNestedQuery: FunctionReference<
         "mutation",
         "internal",

--- a/convex/counter/component/public.ts
+++ b/convex/counter/component/public.ts
@@ -1,6 +1,7 @@
 import { v } from "convex/values";
 import { action, mutation, query } from "./_generated/server";
 import { api } from "./_generated/api";
+import { getFunctionMetadata } from "../../meta";
 
 export const add = mutation({
   args: {
@@ -109,16 +110,9 @@ export const mutationWithNumberArg = mutation({
   },
 });
 
-// TODO: replace with ctx.meta.getFunctionMetadata() in 1.36+
 export const metadata = query({
   args: {},
   handler: async () => {
-    const syscalls = (global as any).Convex;
-    return JSON.parse(
-      await syscalls.asyncSyscall(
-        "1.0/getFunctionMetadata",
-        JSON.stringify({}),
-      ),
-    );
+    return await getFunctionMetadata();
   },
 });

--- a/convex/counter/component/public.ts
+++ b/convex/counter/component/public.ts
@@ -108,3 +108,17 @@ export const mutationWithNumberArg = mutation({
     return args.a;
   },
 });
+
+// TODO: replace with ctx.meta.getFunctionMetadata() in 1.36+
+export const metadata = query({
+  args: {},
+  handler: async () => {
+    const syscalls = (global as any).Convex;
+    return JSON.parse(
+      await syscalls.asyncSyscall(
+        "1.0/getFunctionMetadata",
+        JSON.stringify({}),
+      ),
+    );
+  },
+});

--- a/convex/getFunctionMetadata.test.ts
+++ b/convex/getFunctionMetadata.test.ts
@@ -5,15 +5,9 @@ import { convexTest } from "../index";
 import schema from "./schema";
 import { api, components } from "./_generated/api";
 import counterSchema from "./counter/component/schema";
+import { getFunctionMetadata } from "./meta";
 
 const counterModules = import.meta.glob("./counter/component/**/*.ts");
-
-async function getFunctionMetadata() {
-  const syscalls = (global as any).Convex;
-  return JSON.parse(
-    await syscalls.asyncSyscall("1.0/getFunctionMetadata", JSON.stringify({})),
-  );
-}
 
 test("inline query", async () => {
   const t = convexTest({ schema });

--- a/convex/getFunctionMetadata.test.ts
+++ b/convex/getFunctionMetadata.test.ts
@@ -1,0 +1,93 @@
+/// <reference types="vite/client" />
+
+import { expect, test } from "vitest";
+import { convexTest } from "../index";
+import schema from "./schema";
+import { api, components } from "./_generated/api";
+import counterSchema from "./counter/component/schema";
+
+const counterModules = import.meta.glob("./counter/component/**/*.ts");
+
+async function getFunctionMetadata() {
+  const syscalls = (global as any).Convex;
+  return JSON.parse(
+    await syscalls.asyncSyscall("1.0/getFunctionMetadata", JSON.stringify({})),
+  );
+}
+
+test("inline query", async () => {
+  const t = convexTest({ schema });
+  const metadata = await t.query(async () => {
+    return await getFunctionMetadata();
+  });
+  expect(metadata).toEqual({ name: "inline", componentPath: "" });
+});
+
+test("inline mutation", async () => {
+  const t = convexTest({ schema });
+  const metadata = await t.mutation(async () => {
+    return await getFunctionMetadata();
+  });
+  expect(metadata).toEqual({ name: "inline", componentPath: "" });
+});
+
+test("inline action", async () => {
+  const t = convexTest({ schema });
+  const metadata = await t.action(async () => {
+    return await getFunctionMetadata();
+  });
+  expect(metadata).toEqual({ name: "inline", componentPath: "" });
+});
+
+test("named query", async () => {
+  const t = convexTest({ schema });
+  const metadata = await t.query(api.getFunctionMetadata.metadataQuery);
+  expect(metadata).toEqual({
+    name: "getFunctionMetadata:metadataQuery",
+    componentPath: "",
+  });
+});
+
+test("named mutation", async () => {
+  const t = convexTest({ schema });
+  const metadata = await t.mutation(api.getFunctionMetadata.metadataMutation);
+  expect(metadata).toEqual({
+    name: "getFunctionMetadata:metadataMutation",
+    componentPath: "",
+  });
+});
+
+test("named action", async () => {
+  const t = convexTest({ schema });
+  const metadata = await t.action(api.getFunctionMetadata.metadataAction);
+  expect(metadata).toEqual({
+    name: "getFunctionMetadata:metadataAction",
+    componentPath: "",
+  });
+});
+
+test("default export", async () => {
+  const t = convexTest({ schema });
+  const metadata = await t.query(api.getFunctionMetadata.default);
+  expect(metadata).toEqual({
+    name: "getFunctionMetadata",
+    componentPath: "",
+  });
+});
+
+test("http action", async () => {
+  const t = convexTest(schema);
+  const response = await t.fetch("/metadata", { method: "GET" });
+  const metadata = await response.json();
+  expect(metadata).toEqual({ name: "http", componentPath: "" });
+});
+
+test("component function has component path", async () => {
+  const t = convexTest(schema);
+  t.registerComponent("counter", counterSchema, counterModules);
+  const metadata = await t.query(components.counter.public.metadata);
+  expect(metadata).toEqual({
+    name: "public:metadata",
+    componentPath: "counter",
+  });
+});

--- a/convex/getFunctionMetadata.ts
+++ b/convex/getFunctionMetadata.ts
@@ -1,0 +1,37 @@
+import { action, mutation, query } from "./_generated/server";
+
+// TODO: replace with ctx.meta.getFunctionMetadata() in 1.36+
+async function getFunctionMetadata() {
+  const syscalls = (global as any).Convex;
+  return JSON.parse(
+    await syscalls.asyncSyscall("1.0/getFunctionMetadata", JSON.stringify({})),
+  );
+}
+
+export const metadataQuery = query({
+  args: {},
+  handler: async () => {
+    return await getFunctionMetadata();
+  },
+});
+
+export const metadataMutation = mutation({
+  args: {},
+  handler: async () => {
+    return await getFunctionMetadata();
+  },
+});
+
+export const metadataAction = action({
+  args: {},
+  handler: async () => {
+    return await getFunctionMetadata();
+  },
+});
+
+export default query({
+  args: {},
+  handler: async () => {
+    return await getFunctionMetadata();
+  },
+});

--- a/convex/getFunctionMetadata.ts
+++ b/convex/getFunctionMetadata.ts
@@ -1,12 +1,5 @@
 import { action, mutation, query } from "./_generated/server";
-
-// TODO: replace with ctx.meta.getFunctionMetadata() in 1.36+
-async function getFunctionMetadata() {
-  const syscalls = (global as any).Convex;
-  return JSON.parse(
-    await syscalls.asyncSyscall("1.0/getFunctionMetadata", JSON.stringify({})),
-  );
-}
+import { getFunctionMetadata } from "./meta";
 
 export const metadataQuery = query({
   args: {},

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -45,4 +45,19 @@ export const getFirst = internalQuery(async (ctx) => {
   return await ctx.db.query("messages").first();
 });
 
+http.route({
+  path: "/metadata",
+  method: "GET",
+  handler: httpAction(async () => {
+    const syscalls = (global as any).Convex;
+    const metadata = JSON.parse(
+      await syscalls.asyncSyscall(
+        "1.0/getFunctionMetadata",
+        JSON.stringify({}),
+      ),
+    );
+    return new Response(JSON.stringify(metadata), { status: 200 });
+  }),
+});
+
 export default http;

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -1,6 +1,7 @@
 import { httpRouter } from "convex/server";
 import { internal } from "./_generated/api";
 import { httpAction, internalQuery } from "./_generated/server";
+import { getFunctionMetadata } from "./meta";
 
 const http = httpRouter();
 
@@ -49,13 +50,7 @@ http.route({
   path: "/metadata",
   method: "GET",
   handler: httpAction(async () => {
-    const syscalls = (global as any).Convex;
-    const metadata = JSON.parse(
-      await syscalls.asyncSyscall(
-        "1.0/getFunctionMetadata",
-        JSON.stringify({}),
-      ),
-    );
+    const metadata = await getFunctionMetadata();
     return new Response(JSON.stringify(metadata), { status: 200 });
   }),
 });

--- a/convex/meta.ts
+++ b/convex/meta.ts
@@ -1,0 +1,35 @@
+// TODO: replace with ctx.meta.getFunctionMetadata() in 1.36+
+export async function getFunctionMetadata(): Promise<{
+  name: string;
+  componentPath: string;
+}> {
+  const syscalls = (global as any).Convex;
+  return JSON.parse(
+    await syscalls.asyncSyscall("1.0/getFunctionMetadata", JSON.stringify({})),
+  );
+}
+
+type TransactionMetric = {
+  used: number;
+  remaining: number;
+};
+
+type TransactionMetrics = {
+  bytesRead: TransactionMetric;
+  bytesWritten: TransactionMetric;
+  databaseQueries: TransactionMetric;
+  documentsRead: TransactionMetric;
+  documentsWritten: TransactionMetric;
+  functionsScheduled: TransactionMetric;
+  scheduledFunctionArgsBytes: TransactionMetric;
+};
+
+export async function getTransactionMetrics(): Promise<TransactionMetrics> {
+  const syscalls = (global as any).Convex;
+  return JSON.parse(
+    await syscalls.asyncSyscall(
+      "1.0/getTransactionMetrics",
+      JSON.stringify({}),
+    ),
+  );
+}

--- a/index.ts
+++ b/index.ts
@@ -1398,7 +1398,7 @@ function asyncSyscallImpl() {
       }
       case "1.0/getTransactionMetrics": {
         if (tracker) {
-          return JSON.stringify(tracker.getTransactionMetrics());
+          return JSON.stringify(convexToJson(tracker.getTransactionMetrics()));
         }
         throw new Error(
           "getTransactionMetrics() can only be called from a query or mutation. " +
@@ -1412,10 +1412,12 @@ function asyncSyscallImpl() {
             "getFunctionMetadata() can only be called from within a Convex function.",
           );
         }
-        return JSON.stringify({
-          name: ctx.udfPath,
-          componentPath: ctx.componentPath,
-        });
+        return JSON.stringify(
+          convexToJson({
+            name: ctx.udfPath,
+            componentPath: ctx.componentPath,
+          }),
+        );
       }
       case "1.0/actions/query": {
         const { name, args: queryArgs } = args;

--- a/index.ts
+++ b/index.ts
@@ -1402,6 +1402,27 @@ function asyncSyscallImpl() {
             "It is not available in actions or outside of a Convex function.",
         );
       }
+      case "1.0/getTransactionMetrics": {
+        if (tracker) {
+          return JSON.stringify(tracker.getTransactionHeadroom());
+        }
+        throw new Error(
+          "getTransactionMetrics() can only be called from a query or mutation. " +
+            "It is not available in actions or outside of a Convex function.",
+        );
+      }
+      case "1.0/getFunctionMetadata": {
+        const ctx = executionContextStorage.getStore();
+        if (!ctx) {
+          throw new Error(
+            "getFunctionMetadata() can only be called from within a Convex function.",
+          );
+        }
+        return JSON.stringify({
+          name: ctx.udfPath,
+          componentPath: ctx.componentPath,
+        });
+      }
       case "1.0/actions/query": {
         const { name, args: queryArgs } = args;
         return JSON.stringify(

--- a/index.ts
+++ b/index.ts
@@ -2648,11 +2648,18 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
         };
         return getHandler(func)(testCtx, a);
       });
-      const response = await (
-        a as unknown as {
-          invokeHttpAction: (request: Request) => Promise<Response>;
-        }
-      ).invokeHttpAction(new Request(url, init));
+      const httpCtx: ExecutionContext = {
+        componentPath: getCurrentComponentPath(),
+        udfPath: "http",
+        depth: 0,
+      };
+      const response = await executionContextStorage.run(httpCtx, () =>
+        (
+          a as unknown as {
+            invokeHttpAction: (request: Request) => Promise<Response>;
+          }
+        ).invokeHttpAction(new Request(url, init)),
+      );
       return response;
     },
 

--- a/index.ts
+++ b/index.ts
@@ -39,7 +39,10 @@ import {
   getDocumentSize,
   jsonToConvex,
 } from "convex/values";
-import { HeadroomTracker, TransactionMetrics } from "./headroom.js";
+import {
+  TransactionMetricsTracker,
+  TransactionMetrics,
+} from "./transactionMetrics.js";
 
 type FilterJson =
   | { $eq: [FilterJson, FilterJson] }
@@ -1277,7 +1280,7 @@ function syscallImpl() {
     switch (op) {
       case "1.0/queryStream": {
         const { query } = args;
-        const tracker = getTransactionManager().getHeadroomTracker();
+        const tracker = getTransactionManager().getMetricsTracker();
         tracker?.trackIndexRange();
         const queryId = db.startQuery(query);
         return JSON.stringify({ queryId });
@@ -1311,7 +1314,7 @@ function asyncSyscallImpl() {
   return async (op: string, jsonArgs: string): Promise<string> => {
     const args = JSON.parse(jsonArgs);
     const db = getDb();
-    const tracker = getTransactionManager().getHeadroomTracker();
+    const tracker = getTransactionManager().getMetricsTracker();
     function getAndTrack(table: string, id: GenericId<string>) {
       const doc = db.get(table, id);
       if (doc !== null) {
@@ -1393,18 +1396,9 @@ function asyncSyscallImpl() {
         tracker?.trackWrite(0);
         return JSON.stringify({});
       }
-      case "1.0/headroom": {
-        if (tracker) {
-          return JSON.stringify(convexToJson(tracker.getTransactionHeadroom()));
-        }
-        throw new Error(
-          "getTransactionHeadroom() can only be called from a query or mutation. " +
-            "It is not available in actions or outside of a Convex function.",
-        );
-      }
       case "1.0/getTransactionMetrics": {
         if (tracker) {
-          return JSON.stringify(tracker.getTransactionHeadroom());
+          return JSON.stringify(tracker.getTransactionMetrics());
         }
         throw new Error(
           "getTransactionMetrics() can only be called from a query or mutation. " +
@@ -2054,7 +2048,7 @@ class TransactionManager {
   // can run mutations in parallel.
   private _waitOnCurrentFunction: Promise<void> | null = null;
   private _markTransactionDone: (() => void) | null = null;
-  private _headroomTracker: HeadroomTracker | null = null;
+  private _metricsTracker: TransactionMetricsTracker | null = null;
   private _limitsConfig: Partial<TransactionMetrics> | boolean;
 
   constructor(limitsConfig: Partial<TransactionMetrics> | boolean = false) {
@@ -2076,7 +2070,7 @@ class TransactionManager {
       this._waitOnCurrentFunction = new Promise((resolve) => {
         this._markTransactionDone = resolve;
       });
-      this._headroomTracker = new HeadroomTracker(this._limitsConfig);
+      this._metricsTracker = new TransactionMetricsTracker(this._limitsConfig);
     }
     const convex = getConvexGlobal();
     for (const component of Object.values(convex.components)) {
@@ -2090,8 +2084,8 @@ class TransactionManager {
     return this._waitOnCurrentFunction !== null;
   }
 
-  getHeadroomTracker(): HeadroomTracker | null {
-    return this._headroomTracker;
+  getMetricsTracker(): TransactionMetricsTracker | null {
+    return this._metricsTracker;
   }
 
   commit(isNested: boolean) {
@@ -2115,7 +2109,7 @@ class TransactionManager {
       throw new Error("Transaction not started");
     }
     if (!isNested) {
-      this._headroomTracker = null;
+      this._metricsTracker = null;
       this._waitOnCurrentFunction = null;
       this._markTransactionDone();
       this._markTransactionDone = null;

--- a/transactionMetrics.ts
+++ b/transactionMetrics.ts
@@ -20,7 +20,7 @@ const DEFAULT_TRANSACTION_LIMITS: TransactionMetrics = {
   scheduledFunctionArgsBytes: 16 * MiB,
 };
 
-export class HeadroomTracker {
+export class TransactionMetricsTracker {
   private _metrics: TransactionMetrics;
   private _limits: TransactionMetrics;
   private _enforceLimits: boolean;
@@ -123,7 +123,7 @@ export class HeadroomTracker {
     }
   }
 
-  getTransactionHeadroom() {
+  getTransactionMetrics() {
     return {
       bytesRead: {
         used: this._metrics.bytesRead,


### PR DESCRIPTION
## Implement getFunctionMetadata syscall and rename transaction metrics APIs

### Rename transaction metrics components
- Rename `HeadroomTracker` class to `TransactionMetricsTracker`
- Rename `headroom.ts` file to `transactionMetrics.ts`
- Update `getTransactionHeadroom()` method to `getTransactionMetrics()`
- Replace `1.0/headroom` syscall with `1.0/getTransactionMetrics`
- Update all references from headroom terminology to metrics terminology

### Add getFunctionMetadata syscall
- Implement `1.0/getFunctionMetadata` syscall that returns function name and component path
- Add validation to ensure it can only be called from within a Convex function

### Enhance transaction metrics testing
- Add comprehensive assertions for remaining capacity tracking
- Add new test case for write operation tracking
- Verify proper tracking of documents written and bytes written metrics

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a runtime function metadata endpoint (available via API and HTTP) and a component metadata query.

* **Enhancements**
  * Transaction metrics now report precise counts and byte totals for reads and writes, plus scheduled-work values.

* **Tests**
  * Added/updated tests validating metadata lookup, transaction metrics (read/write tracking), and scheduled-function authentication behavior.

* **Refactor**
  * Replaced legacy headroom tracking with an expanded transaction metrics system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->