### PR TITLE
readable but more realistic IDs

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -833,11 +833,11 @@ class DatabaseFake {
 }
 
 function tableNameFromId(id: string) {
-  if (id.length !== 38) {
+  if (id.length < 4) {
     return null;
   }
-  const nameLen = Number(id.slice(35));
-  if (isNaN(nameLen) || nameLen <= 0) {
+  const nameLen = Number(id.slice(-3));
+  if (isNaN(nameLen) || nameLen <= 0 || nameLen > id.length - 3) {
     return null;
   }
   return id.slice(0, nameLen);

--- a/index.ts
+++ b/index.ts
@@ -41,6 +41,10 @@ import {
 } from "convex/values";
 import { HeadroomTracker, TransactionMetrics } from "./headroom.js";
 
+// Real Convex IDs are 32 characters. IDs may exceed this length for very long
+// table names or large numbers of documents, but this is the typical target.
+const TYPICAL_CONVEX_ID_LENGTH = 32;
+
 type FilterJson =
   | { $eq: [FilterJson, FilterJson] }
   | { $field: string }
@@ -218,7 +222,7 @@ class DatabaseFake {
   private _generateId<TableName extends string>(
     table: TableName,
   ): GenericId<TableName> {
-    const counterPadLen = 38 - table.length - 3;
+    const counterPadLen = TYPICAL_CONVEX_ID_LENGTH - table.length - 3;
     const counter = this._nextDocId.toString().padStart(counterPadLen, "0");
     const nameLen = table.length.toString().padStart(3, "0");
     const id = table + counter + nameLen;

--- a/index.ts
+++ b/index.ts
@@ -222,10 +222,9 @@ class DatabaseFake {
   private _generateId<TableName extends string>(
     table: TableName,
   ): GenericId<TableName> {
-    const counterPadLen = TYPICAL_CONVEX_ID_LENGTH - table.length - 3;
+    const counterPadLen = TYPICAL_CONVEX_ID_LENGTH - table.length;
     const counter = this._nextDocId.toString().padStart(counterPadLen, "0");
-    const nameLen = table.length.toString().padStart(3, "0");
-    const id = table + counter + nameLen;
+    const id = counter + table;
     this._nextDocId += 1;
     return id as GenericId<TableName>;
   }
@@ -837,14 +836,11 @@ class DatabaseFake {
 }
 
 function tableNameFromId(id: string) {
-  if (id.length < 4) {
+  const match = id.match(/^[0-9]+/);
+  if (!match || match[0].length === id.length) {
     return null;
   }
-  const nameLen = Number(id.slice(-3));
-  if (isNaN(nameLen) || nameLen <= 0 || nameLen > id.length - 3) {
-    return null;
-  }
-  return id.slice(0, nameLen);
+  return id.slice(match[0].length);
 }
 
 function isSimpleObject(value: unknown) {

--- a/index.ts
+++ b/index.ts
@@ -218,7 +218,10 @@ class DatabaseFake {
   private _generateId<TableName extends string>(
     table: TableName,
   ): GenericId<TableName> {
-    const id = this._nextDocId.toString() + ";" + table;
+    const counterPadLen = 38 - table.length - 3;
+    const counter = this._nextDocId.toString().padStart(counterPadLen, "0");
+    const nameLen = table.length.toString().padStart(3, "0");
+    const id = table + counter + nameLen;
     this._nextDocId += 1;
     return id as GenericId<TableName>;
   }
@@ -830,11 +833,14 @@ class DatabaseFake {
 }
 
 function tableNameFromId(id: string) {
-  const parts = id.split(";");
-  if (parts.length !== 2) {
+  if (id.length !== 38) {
     return null;
   }
-  return id.split(";")[1];
+  const nameLen = Number(id.slice(35));
+  if (isNaN(nameLen) || nameLen <= 0) {
+    return null;
+  }
+  return id.slice(0, nameLen);
 }
 
 function isSimpleObject(value: unknown) {
@@ -1287,9 +1293,9 @@ function syscallImpl() {
       }
       case "1.0/db/normalizeId": {
         const idString: string = args.idString;
-        const isInTable = idString.endsWith(`;${args.table}`);
+        const tableName = tableNameFromId(idString);
         return JSON.stringify({
-          id: isInTable ? idString : null,
+          id: tableName === args.table ? idString : null,
         });
       }
       default: {


### PR DESCRIPTION
## Improved ID format for better readability and consistency

Changed the ID generation format from `counter;tableName` to `paddedCounter + tableName`, where the counter is zero-padded to maintain a typical 32-character ID length. This creates more consistent ID formatting while supporting variable table name lengths, using only alpha-numeric characters, as normal IDs do.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->