### PR TITLE
implement audit log syscall as no-op

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -10,6 +10,7 @@
 
 import type * as actions from "../actions.js";
 import type * as argumentsValidation from "../argumentsValidation.js";
+import type * as auditLogging from "../auditLogging.js";
 import type * as authentication from "../authentication.js";
 import type * as component from "../component.js";
 import type * as convexError from "../convexError.js";
@@ -37,6 +38,7 @@ import type {
 declare const fullApi: ApiFromModules<{
   actions: typeof actions;
   argumentsValidation: typeof argumentsValidation;
+  auditLogging: typeof auditLogging;
   authentication: typeof authentication;
   component: typeof component;
   convexError: typeof convexError;

--- a/convex/auditLogging.test.ts
+++ b/convex/auditLogging.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from "vitest";
+import { convexTest } from "../index";
+import { api } from "./_generated/api";
+import schema from "./schema";
+
+test("log.audit no-ops", async () => {
+  const t = convexTest(schema);
+  const result = await t.query(api.auditLogging.loggedQuery);
+  expect(result).toBe("ok");
+});

--- a/convex/auditLogging.ts
+++ b/convex/auditLogging.ts
@@ -1,0 +1,13 @@
+import { log } from "convex/server";
+import { query } from "./_generated/server";
+
+export const loggedQuery = query({
+  args: {},
+  handler: async () => {
+    await log.audit({
+      action: "meow",
+      ip: log.vars.ip,
+    });
+    return "ok";
+  },
+});

--- a/index.ts
+++ b/index.ts
@@ -1353,7 +1353,7 @@ class AuthFake {
 }
 
 function asyncSyscallImpl() {
-  return async (op: string, jsonArgs: string): Promise<string> => {
+  return async (op: string, jsonArgs: string): Promise<string | undefined> => {
     const args = JSON.parse(jsonArgs);
     const db = getDb();
     const tracker = getTransactionManager().getMetricsTracker();
@@ -1711,6 +1711,9 @@ function asyncSyscallImpl() {
           count += 1;
         }
         return JSON.stringify(count);
+      }
+      case "1.0/auditLog": {
+        return;
       }
       default: {
         throw new Error(

--- a/index.ts
+++ b/index.ts
@@ -1353,7 +1353,7 @@ class AuthFake {
 }
 
 function asyncSyscallImpl() {
-  return async (op: string, jsonArgs: string): Promise<string | undefined> => {
+  return async (op: string, jsonArgs: string): Promise<string> => {
     const args = JSON.parse(jsonArgs);
     const db = getDb();
     const tracker = getTransactionManager().getMetricsTracker();
@@ -1713,7 +1713,7 @@ function asyncSyscallImpl() {
         return JSON.stringify(count);
       }
       case "1.0/auditLog": {
-        return;
+        return JSON.stringify(null);
       }
       default: {
         throw new Error(

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@typescript-eslint/eslint-plugin": "8.58.2",
         "@typescript-eslint/parser": "8.58.2",
         "@vitest/coverage-v8": "1.6.1",
-        "convex": "1.36.0",
+        "convex": "1.38.0",
         "eslint": "9.39.4",
         "globals": "17.5.0",
         "pkg-pr-new": "0.0.66",
@@ -2210,9 +2210,9 @@
       "license": "MIT"
     },
     "node_modules/convex": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/convex/-/convex-1.36.0.tgz",
-      "integrity": "sha512-17cfDr2z+Apd59291rKWij6jq79eVwzY9u2MQOnuVkOsfEPXcuerWHQLf1ngXAbQjeTXD1nwQYsxQBhZnjZMIQ==",
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/convex/-/convex-1.38.0.tgz",
+      "integrity": "sha512-122AC6y5lUS7mr39cluLw9+TOtRX5d/XxeivHhHObs/NTXoVvOnIgDzexVcxaz6Rk0oLFSoydSR1rDCltEz/0A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2230,7 +2230,7 @@
       "peerDependencies": {
         "@auth0/auth0-react": "^2.0.1",
         "@clerk/clerk-react": "^4.12.8 || ^5.0.0",
-        "@clerk/react": "^6.0.0",
+        "@clerk/react": "^6.4.3",
         "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
@@ -6247,9 +6247,9 @@
       "dev": true
     },
     "convex": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/convex/-/convex-1.36.0.tgz",
-      "integrity": "sha512-17cfDr2z+Apd59291rKWij6jq79eVwzY9u2MQOnuVkOsfEPXcuerWHQLf1ngXAbQjeTXD1nwQYsxQBhZnjZMIQ==",
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/convex/-/convex-1.38.0.tgz",
+      "integrity": "sha512-122AC6y5lUS7mr39cluLw9+TOtRX5d/XxeivHhHObs/NTXoVvOnIgDzexVcxaz6Rk0oLFSoydSR1rDCltEz/0A==",
       "dev": true,
       "requires": {
         "esbuild": "0.27.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@typescript-eslint/eslint-plugin": "8.58.2",
     "@typescript-eslint/parser": "8.58.2",
     "@vitest/coverage-v8": "1.6.1",
-    "convex": "1.36.0",
+    "convex": "1.38.0",
     "eslint": "9.39.4",
     "globals": "17.5.0",
     "pkg-pr-new": "0.0.66",


### PR DESCRIPTION
Implement the `1.0/auditLog` syscall as a no-op. 

Users that want to test audit log output can directly spyOn `log.audit`.