### PR TITLE
re-acquire global lock for transactions from scheduled fns

### DIFF
--- a/convex/scheduler.test.ts
+++ b/convex/scheduler.test.ts
@@ -114,6 +114,8 @@ test("action scheduling action", async () => {
 });
 
 test("action scheduling action many times", async () => {
+  // Also ensures that recursively-scheduled functions are detected by
+  // finishAllScheduledFunctions across iterations.
   vi.useFakeTimers();
   const t = convexTest(schema);
   await t.action(api.scheduler.actionSchedulingActionNTimes, {

--- a/convex/scheduler.test.ts
+++ b/convex/scheduler.test.ts
@@ -214,6 +214,133 @@ test("new convexTest after orphaned scheduled functions", async () => {
   expect(result).toMatchObject([{ body: "fresh", author: "test" }]);
 });
 
+test("advancing time fires only jobs whose scheduledTime has arrived", async () => {
+  vi.useFakeTimers();
+  const t = convexTest(schema);
+  await t.mutation(api.scheduler.scheduleNowAndLater, {});
+
+  // Fire the immediate (delay=0) but not the delayed (delay=60s).
+  vi.advanceTimersByTime(0);
+  await t.finishInProgressScheduledFunctions();
+
+  expect(await t.query(internal.scheduler.list)).toMatchObject([
+    { body: "immediate" },
+  ]);
+  const jobs = await t.query(internal.scheduler.jobs);
+  expect(
+    jobs.filter((j: { state: { kind: string } }) => j.state.kind === "pending"),
+  ).toHaveLength(1);
+  expect(
+    jobs.filter((j: { state: { kind: string } }) => j.state.kind === "success"),
+  ).toHaveLength(1);
+
+  // Drain the delayed one too.
+  await t.finishAllScheduledFunctions(vi.runAllTimers);
+  expect(await t.query(internal.scheduler.list)).toMatchObject([
+    { body: "immediate" },
+    { body: "delayed" },
+  ]);
+  vi.useRealTimers();
+});
+
+test("scheduled functions don't fire until time advances", async () => {
+  vi.useFakeTimers();
+  const t = convexTest(schema);
+
+  await t.mutation(api.scheduler.mutationSchedulingAction, {
+    body: "scheduled",
+    delayMs: 0,
+  });
+
+  // Without advancing fake timers, the scheduler's setTimeout doesn't fire,
+  // so the job is still pending and nothing has executed.
+  const jobsBefore = await t.query(internal.scheduler.jobs);
+  expect(jobsBefore).toMatchObject([{ state: { kind: "pending" } }]);
+
+  vi.runAllTimers();
+  await t.finishInProgressScheduledFunctions();
+
+  const jobsAfter = await t.query(internal.scheduler.jobs);
+  expect(jobsAfter).toMatchObject([{ state: { kind: "success" } }]);
+  vi.useRealTimers();
+});
+
+test("scheduled mutations serialize after the parent commits", async () => {
+  vi.useFakeTimers();
+  const t = convexTest(schema);
+  await t.mutation(async (ctx) => {
+    await ctx.scheduler.runAfter(0, api.scheduler.add, {
+      body: "A-scheduled",
+      author: "AI",
+    });
+    await ctx.db.insert("messages", { body: "B-parent-after", author: "ME" });
+  });
+  vi.runAllTimers();
+  await t.finishInProgressScheduledFunctions();
+
+  const messages = await t.query(internal.scheduler.list);
+  expect(messages.map((m: { body: string }) => m.body)).toEqual([
+    "B-parent-after",
+    "A-scheduled",
+  ]);
+  vi.useRealTimers();
+});
+
+test("rollback cancels scheduled function", async () => {
+  vi.useFakeTimers();
+  const t = convexTest(schema);
+  await expect(
+    t.mutation(async (ctx) => {
+      await ctx.scheduler.runAfter(0, api.scheduler.add, {
+        body: "should-not-run",
+        author: "AI",
+      });
+      throw new Error("rollback");
+    }),
+  ).rejects.toThrowError(/rollback/);
+
+  vi.runAllTimers();
+  await t.finishInProgressScheduledFunctions();
+
+  const messages = await t.query(internal.scheduler.list);
+  expect(messages).toEqual([]);
+  const jobs = await t.query(internal.scheduler.jobs);
+  expect(jobs).toEqual([]);
+  vi.useRealTimers();
+});
+
+test("scheduling from a nested mutation still runs as top-level", async () => {
+  // Regression test: the schedule syscall runs inside a `ctx.runMutation`,
+  // i.e. with a non-null `nestedTxStorage` parent lock. The fired
+  // setTimeout callback must still acquire the global lock (not behave as
+  // if it were nested inside the long-gone parent transaction).
+  vi.useFakeTimers();
+  const t = convexTest(schema);
+  await t.mutation(api.scheduler.parentRunsMutationThatSchedules, {
+    body: "from-nested",
+  });
+  vi.runAllTimers();
+  await t.finishInProgressScheduledFunctions();
+  const messages = await t.query(internal.scheduler.list);
+  expect(messages.map((m: { body: string }) => m.body)).toEqual([
+    "from-nested",
+  ]);
+  vi.useRealTimers();
+});
+
+test("action can schedule a mutation and poll for its effect without finish*", async () => {
+  // Real timers: the scheduled mutation's setTimeout fires naturally
+  // while the action is awaiting its poll sleep. The action's runQuery
+  // releases the mutation lock between iterations, letting the scheduled
+  // mutation acquire it and commit.
+  const t = convexTest(schema);
+  await t.action(api.scheduler.actionSchedulesMutationAndPolls, {
+    body: "polled",
+  });
+  const messages = await t.query(internal.scheduler.list);
+  expect(messages.map((m: { body: string }) => m.body)).toEqual(["polled"]);
+});
+
 test("argument serialization", async () => {
   vi.useFakeTimers();
   const t = convexTest(schema);

--- a/convex/scheduler.test.ts
+++ b/convex/scheduler.test.ts
@@ -1,382 +1,379 @@
-import { expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { convexTest } from "../index";
 import { api, internal } from "./_generated/api";
 import schema from "./schema";
 
-test("mutation scheduling action", async () => {
-  vi.useFakeTimers();
-  const t = convexTest(schema);
-  await t.mutation(api.scheduler.mutationSchedulingAction, {
-    delayMs: 10000,
-    body: "through scheduler",
+describe("with fake timers", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
   });
-  {
-    const jobs = await t.query(internal.scheduler.jobs);
-    expect(jobs).toMatchObject([
-      { state: { kind: "pending" }, args: [{ body: "through scheduler" }] },
-    ]);
-  }
-
-  vi.advanceTimersByTime(5000);
-
-  {
-    const jobs = await t.query(internal.scheduler.jobs);
-    expect(jobs).toMatchObject([{ state: { kind: "pending" } }]);
-  }
-
-  vi.runAllTimers();
-
-  await t.finishInProgressScheduledFunctions();
-
-  const result = await t.query(internal.scheduler.list);
-  expect(result).toMatchObject([{ body: "through scheduler", author: "AI" }]);
-  {
-    const jobs = await t.query(internal.scheduler.jobs);
-    expect(jobs).toMatchObject([{ state: { kind: "success" } }]);
-  }
-  vi.useRealTimers();
-});
-
-test("mutation scheduling action then mutation fails", async () => {
-  vi.useFakeTimers();
-  const t = convexTest(schema);
-  await t.mutation(api.scheduler.mutationSchedulingAction, {
-    delayMs: 10000,
-    body: "through scheduler",
-  });
-  vi.runAllTimers();
-  await t.finishInProgressScheduledFunctions();
-  {
-    const jobs = await t.query(internal.scheduler.jobs);
-    expect(jobs).toMatchObject([{ state: { kind: "success" } }]);
-  }
-  // An unrelated mutation throws an error.
-  // This does not affect the scheduled functions which have already run and
-  // committed.
-  // This is a regression test: previously the error would cause the scheduled
-  // function to go back to "inProgress".
-  try {
-    await t.mutation(api.scheduler.add, { body: "FAIL THIS", author: "AI" });
-  } catch (e: any) {
-    expect(e.message).toBe("failed as intended");
-  }
-  {
-    const jobs = await t.query(internal.scheduler.jobs);
-    expect(jobs).toMatchObject([{ state: { kind: "success" } }]);
-  }
-  vi.useRealTimers();
-});
-
-test("cancel mutation", async () => {
-  vi.useFakeTimers();
-  const t = convexTest(schema);
-  const id = await t.mutation(api.scheduler.mutationSchedulingAction, {
-    body: "through scheduler",
-    delayMs: 10000,
-  });
-  await t.mutation(api.scheduler.cancel, { id });
-  const jobs = await t.query(internal.scheduler.jobs);
-  expect(jobs).toMatchObject([{ state: { kind: "canceled" } }]);
-
-  vi.runAllTimers();
-  await t.finishInProgressScheduledFunctions();
-
-  const result = await t.query(internal.scheduler.list);
-  expect(result).toMatchObject([]);
-  vi.useRealTimers();
-});
-
-test("action scheduling action", async () => {
-  vi.useFakeTimers();
-  const t = convexTest(schema);
-  await t.action(api.scheduler.actionSchedulingAction, {
-    delayMs: 0,
-    body: "through scheduler",
-  });
-  {
-    const jobs = await t.query(internal.scheduler.jobs);
-    expect(jobs).toMatchObject([
-      { state: { kind: "pending" }, args: [{ body: "through scheduler" }] },
-    ]);
-  }
-
-  vi.runAllTimers();
-
-  await t.finishInProgressScheduledFunctions();
-
-  const result = await t.query(internal.scheduler.list);
-  expect(result).toMatchObject([{ body: "through scheduler", author: "AI" }]);
-  {
-    const jobs = await t.query(internal.scheduler.jobs);
-    expect(jobs).toMatchObject([{ state: { kind: "success" } }]);
-  }
-  vi.useRealTimers();
-});
-
-test("action scheduling action many times", async () => {
-  // Also ensures that recursively-scheduled functions are detected by
-  // finishAllScheduledFunctions across iterations.
-  vi.useFakeTimers();
-  const t = convexTest(schema);
-  await t.action(api.scheduler.actionSchedulingActionNTimes, {
-    count: 10,
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
-  await t.finishAllScheduledFunctions(vi.runAllTimers);
-
-  const result = (await t.query(internal.scheduler.list)).at(-1);
-  expect(result).toMatchObject({ body: "count 0", author: "AI" });
-
-  vi.useRealTimers();
-});
-
-test("cancel action", async () => {
-  vi.useFakeTimers();
-  const t = convexTest(schema);
-  const id = await t.action(api.scheduler.actionSchedulingAction, {
-    body: "through scheduler",
-    delayMs: 10000,
-  });
-  await t.action(api.scheduler.cancelAction, { id });
-  const jobs = await t.query(internal.scheduler.jobs);
-  expect(jobs).toMatchObject([{ state: { kind: "canceled" } }]);
-
-  vi.runAllTimers();
-  await t.finishInProgressScheduledFunctions();
-
-  const result = await t.query(internal.scheduler.list);
-  expect(result).toMatchObject([]);
-  vi.useRealTimers();
-});
-
-test("failed scheduled function", async () => {
-  vi.useFakeTimers();
-  const t = convexTest(schema);
-  await t.mutation(api.scheduler.mutationSchedulingAction, {
-    delayMs: 0,
-    body: "FAIL THIS",
-  });
-  vi.runAllTimers();
-  await t.finishInProgressScheduledFunctions();
-  // Regression test: previously this would throw an error that the scheduled
-  // function state is "failed" while it should be "inProgress".
-  const jobs = await t.query(internal.scheduler.jobs);
-  expect(jobs).toMatchObject([
-    { state: { kind: "failed" }, args: [{ body: "FAIL THIS" }] },
-  ]);
-  vi.useRealTimers();
-});
-
-test("self-scheduling mutation", async () => {
-  vi.useFakeTimers();
-  const t = convexTest(schema);
-  await t.mutation(api.scheduler.selfSchedulingMutation, {});
-
-  await expect(
-    t.finishAllScheduledFunctions(vi.runAllTimers),
-  ).rejects.toThrowError(/Check for infinitely recursive scheduled functions/);
-
-  vi.useRealTimers();
-});
-
-test("scheduled action that uses setTimeout internally", async () => {
-  vi.useFakeTimers();
-  const t = convexTest(schema);
-  await t.mutation(api.scheduler.mutationSchedulingActionWithTimeout, {
-    body: "delayed action",
-  });
-  // The scheduled action uses setTimeout(resolve, 100) internally.
-  // finishAllScheduledFunctions needs to pump timers while waiting for
-  // the action to complete, otherwise it will hang.
-  await t.finishAllScheduledFunctions(vi.runAllTimers);
-  const result = await t.query(internal.scheduler.list);
-  expect(result).toMatchObject([{ body: "delayed action", author: "AI" }]);
-  vi.useRealTimers();
-});
-
-test("new convexTest after orphaned scheduled functions", async () => {
-  // First test instance: schedule something and advance timers so the
-  // setTimeout fires, but don't await finishInProgressScheduledFunctions.
-  // This leaves an in-progress function orphaned.
-  vi.useFakeTimers();
-  const t1 = convexTest(schema);
-  await t1.mutation(api.scheduler.mutationSchedulingAction, {
-    body: "orphaned",
-    delayMs: 0,
-  });
-  vi.runAllTimers();
-  // Don't call finishInProgressScheduledFunctions — leave it orphaned
-  vi.useRealTimers();
-
-  // Second test instance: should clean up the orphaned function and not throw
-  const t2 = convexTest(schema);
-  // Verify it works normally
-  await t2.mutation(api.scheduler.add, { body: "fresh", author: "test" });
-  const result = await t2.query(internal.scheduler.list);
-  expect(result).toMatchObject([{ body: "fresh", author: "test" }]);
-});
-
-test("advancing time fires only jobs whose scheduledTime has arrived", async () => {
-  vi.useFakeTimers();
-  const t = convexTest(schema);
-  await t.mutation(api.scheduler.scheduleNowAndLater, {});
-
-  // Fire the immediate (delay=0) but not the delayed (delay=60s).
-  vi.advanceTimersByTime(0);
-  await t.finishInProgressScheduledFunctions();
-
-  expect(await t.query(internal.scheduler.list)).toMatchObject([
-    { body: "immediate" },
-  ]);
-  const jobs = await t.query(internal.scheduler.jobs);
-  expect(
-    jobs.filter((j: { state: { kind: string } }) => j.state.kind === "pending"),
-  ).toHaveLength(1);
-  expect(
-    jobs.filter((j: { state: { kind: string } }) => j.state.kind === "success"),
-  ).toHaveLength(1);
-
-  // Drain the delayed one too.
-  await t.finishAllScheduledFunctions(vi.runAllTimers);
-  expect(await t.query(internal.scheduler.list)).toMatchObject([
-    { body: "immediate" },
-    { body: "delayed" },
-  ]);
-  vi.useRealTimers();
-});
-
-test("scheduled functions don't fire until time advances", async () => {
-  vi.useFakeTimers();
-  const t = convexTest(schema);
-
-  await t.mutation(api.scheduler.mutationSchedulingAction, {
-    body: "scheduled",
-    delayMs: 0,
-  });
-
-  // Without advancing fake timers, the scheduler's setTimeout doesn't fire,
-  // so the job is still pending and nothing has executed.
-  const jobsBefore = await t.query(internal.scheduler.jobs);
-  expect(jobsBefore).toMatchObject([{ state: { kind: "pending" } }]);
-
-  vi.runAllTimers();
-  await t.finishInProgressScheduledFunctions();
-
-  const jobsAfter = await t.query(internal.scheduler.jobs);
-  expect(jobsAfter).toMatchObject([{ state: { kind: "success" } }]);
-  vi.useRealTimers();
-});
-
-test("scheduled mutations serialize after the parent commits", async () => {
-  vi.useFakeTimers();
-  const t = convexTest(schema);
-  await t.mutation(async (ctx) => {
-    await ctx.scheduler.runAfter(0, api.scheduler.add, {
-      body: "A-scheduled",
-      author: "AI",
+  test("mutation scheduling action", async () => {
+    const t = convexTest(schema);
+    await t.mutation(api.scheduler.mutationSchedulingAction, {
+      delayMs: 10000,
+      body: "through scheduler",
     });
-    await ctx.db.insert("messages", { body: "B-parent-after", author: "ME" });
+    {
+      const jobs = await t.query(internal.scheduler.jobs);
+      expect(jobs).toMatchObject([
+        { state: { kind: "pending" }, args: [{ body: "through scheduler" }] },
+      ]);
+    }
+
+    vi.advanceTimersByTime(5000);
+
+    {
+      const jobs = await t.query(internal.scheduler.jobs);
+      expect(jobs).toMatchObject([{ state: { kind: "pending" } }]);
+    }
+
+    vi.runAllTimers();
+
+    await t.finishInProgressScheduledFunctions();
+
+    const result = await t.query(internal.scheduler.list);
+    expect(result).toMatchObject([{ body: "through scheduler", author: "AI" }]);
+    {
+      const jobs = await t.query(internal.scheduler.jobs);
+      expect(jobs).toMatchObject([{ state: { kind: "success" } }]);
+    }
   });
-  vi.runAllTimers();
-  await t.finishInProgressScheduledFunctions();
 
-  const messages = await t.query(internal.scheduler.list);
-  expect(messages.map((m: { body: string }) => m.body)).toEqual([
-    "B-parent-after",
-    "A-scheduled",
-  ]);
-  vi.useRealTimers();
-});
+  test("mutation scheduling action then mutation fails", async () => {
+    const t = convexTest(schema);
+    await t.mutation(api.scheduler.mutationSchedulingAction, {
+      delayMs: 10000,
+      body: "through scheduler",
+    });
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+    {
+      const jobs = await t.query(internal.scheduler.jobs);
+      expect(jobs).toMatchObject([{ state: { kind: "success" } }]);
+    }
+    // An unrelated mutation throws an error.
+    // This does not affect the scheduled functions which have already run and
+    // committed.
+    // This is a regression test: previously the error would cause the scheduled
+    // function to go back to "inProgress".
+    try {
+      await t.mutation(api.scheduler.add, { body: "FAIL THIS", author: "AI" });
+    } catch (e: any) {
+      expect(e.message).toBe("failed as intended");
+    }
+    {
+      const jobs = await t.query(internal.scheduler.jobs);
+      expect(jobs).toMatchObject([{ state: { kind: "success" } }]);
+    }
+  });
 
-test("rollback cancels scheduled function", async () => {
-  vi.useFakeTimers();
-  const t = convexTest(schema);
-  await expect(
-    t.mutation(async (ctx) => {
+  test("cancel mutation", async () => {
+    const t = convexTest(schema);
+    const id = await t.mutation(api.scheduler.mutationSchedulingAction, {
+      body: "through scheduler",
+      delayMs: 10000,
+    });
+    await t.mutation(api.scheduler.cancel, { id });
+    const jobs = await t.query(internal.scheduler.jobs);
+    expect(jobs).toMatchObject([{ state: { kind: "canceled" } }]);
+
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    const result = await t.query(internal.scheduler.list);
+    expect(result).toMatchObject([]);
+  });
+
+  test("action scheduling action", async () => {
+    const t = convexTest(schema);
+    await t.action(api.scheduler.actionSchedulingAction, {
+      delayMs: 0,
+      body: "through scheduler",
+    });
+    {
+      const jobs = await t.query(internal.scheduler.jobs);
+      expect(jobs).toMatchObject([
+        { state: { kind: "pending" }, args: [{ body: "through scheduler" }] },
+      ]);
+    }
+
+    vi.runAllTimers();
+
+    await t.finishInProgressScheduledFunctions();
+
+    const result = await t.query(internal.scheduler.list);
+    expect(result).toMatchObject([{ body: "through scheduler", author: "AI" }]);
+    {
+      const jobs = await t.query(internal.scheduler.jobs);
+      expect(jobs).toMatchObject([{ state: { kind: "success" } }]);
+    }
+  });
+
+  test("action scheduling action many times", async () => {
+    // Also ensures that recursively-scheduled functions are detected by
+    // finishAllScheduledFunctions across iterations.
+    const t = convexTest(schema);
+    await t.action(api.scheduler.actionSchedulingActionNTimes, {
+      count: 10,
+    });
+
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const result = (await t.query(internal.scheduler.list)).at(-1);
+    expect(result).toMatchObject({ body: "count 0", author: "AI" });
+  });
+
+  test("cancel action", async () => {
+    const t = convexTest(schema);
+    const id = await t.action(api.scheduler.actionSchedulingAction, {
+      body: "through scheduler",
+      delayMs: 10000,
+    });
+    await t.action(api.scheduler.cancelAction, { id });
+    const jobs = await t.query(internal.scheduler.jobs);
+    expect(jobs).toMatchObject([{ state: { kind: "canceled" } }]);
+
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    const result = await t.query(internal.scheduler.list);
+    expect(result).toMatchObject([]);
+  });
+
+  test("failed scheduled function", async () => {
+    const t = convexTest(schema);
+    await t.mutation(api.scheduler.mutationSchedulingAction, {
+      delayMs: 0,
+      body: "FAIL THIS",
+    });
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+    // Regression test: previously this would throw an error that the scheduled
+    // function state is "failed" while it should be "inProgress".
+    const jobs = await t.query(internal.scheduler.jobs);
+    expect(jobs).toMatchObject([
+      { state: { kind: "failed" }, args: [{ body: "FAIL THIS" }] },
+    ]);
+  });
+
+  test("self-scheduling mutation", async () => {
+    const t = convexTest(schema);
+    await t.mutation(api.scheduler.selfSchedulingMutation, {});
+
+    await expect(
+      t.finishAllScheduledFunctions(vi.runAllTimers),
+    ).rejects.toThrowError(
+      /Check for infinitely recursive scheduled functions/,
+    );
+  });
+
+  test("scheduled action that uses setTimeout internally", async () => {
+    const t = convexTest(schema);
+    await t.mutation(api.scheduler.mutationSchedulingActionWithTimeout, {
+      body: "delayed action",
+    });
+    // The scheduled action uses setTimeout(resolve, 100) internally.
+    // finishAllScheduledFunctions needs to pump timers while waiting for
+    // the action to complete, otherwise it will hang.
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    const result = await t.query(internal.scheduler.list);
+    expect(result).toMatchObject([{ body: "delayed action", author: "AI" }]);
+  });
+
+  test("new convexTest after orphaned scheduled functions", async () => {
+    // First test instance: schedule something and advance timers so the
+    // setTimeout fires, but don't await finishInProgressScheduledFunctions.
+    // This leaves an in-progress function orphaned.
+    const t1 = convexTest(schema);
+    await t1.mutation(api.scheduler.mutationSchedulingAction, {
+      body: "orphaned",
+      delayMs: 0,
+    });
+    vi.runAllTimers();
+    // Don't call finishInProgressScheduledFunctions — leave it orphaned
+
+    // Second test instance: should clean up the orphaned function and not throw
+    vi.useRealTimers();
+    const t2 = convexTest(schema);
+    // Verify it works normally
+    await t2.mutation(api.scheduler.add, { body: "fresh", author: "test" });
+    const result = await t2.query(internal.scheduler.list);
+    expect(result).toMatchObject([{ body: "fresh", author: "test" }]);
+  });
+
+  test("advancing time fires only jobs whose scheduledTime has arrived", async () => {
+    const t = convexTest(schema);
+    await t.mutation(api.scheduler.scheduleNowAndLater, {});
+
+    // Fire the immediate (delay=0) but not the delayed (delay=60s).
+    vi.advanceTimersByTime(0);
+    await t.finishInProgressScheduledFunctions();
+
+    expect(await t.query(internal.scheduler.list)).toMatchObject([
+      { body: "immediate" },
+    ]);
+    const jobs = await t.query(internal.scheduler.jobs);
+    expect(
+      jobs.filter(
+        (j: { state: { kind: string } }) => j.state.kind === "pending",
+      ),
+    ).toHaveLength(1);
+    expect(
+      jobs.filter(
+        (j: { state: { kind: string } }) => j.state.kind === "success",
+      ),
+    ).toHaveLength(1);
+
+    // Drain the delayed one too.
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    expect(await t.query(internal.scheduler.list)).toMatchObject([
+      { body: "immediate" },
+      { body: "delayed" },
+    ]);
+  });
+
+  test("scheduled functions don't fire until time advances", async () => {
+    const t = convexTest(schema);
+
+    await t.mutation(api.scheduler.mutationSchedulingAction, {
+      body: "scheduled",
+      delayMs: 0,
+    });
+
+    // Without advancing fake timers, the scheduler's setTimeout doesn't fire,
+    // so the job is still pending and nothing has executed.
+    const jobsBefore = await t.query(internal.scheduler.jobs);
+    expect(jobsBefore).toMatchObject([{ state: { kind: "pending" } }]);
+
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    const jobsAfter = await t.query(internal.scheduler.jobs);
+    expect(jobsAfter).toMatchObject([{ state: { kind: "success" } }]);
+  });
+
+  test("scheduled mutations serialize after the parent commits", async () => {
+    const t = convexTest(schema);
+    await t.mutation(async (ctx) => {
       await ctx.scheduler.runAfter(0, api.scheduler.add, {
-        body: "should-not-run",
+        body: "A-scheduled",
         author: "AI",
       });
-      throw new Error("rollback");
-    }),
-  ).rejects.toThrowError(/rollback/);
+      await ctx.db.insert("messages", { body: "B-parent-after", author: "ME" });
+    });
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
 
-  vi.runAllTimers();
-  await t.finishInProgressScheduledFunctions();
-
-  const messages = await t.query(internal.scheduler.list);
-  expect(messages).toEqual([]);
-  const jobs = await t.query(internal.scheduler.jobs);
-  expect(jobs).toEqual([]);
-  vi.useRealTimers();
-});
-
-test("scheduling from a nested mutation still runs as top-level", async () => {
-  // Regression test: the schedule syscall runs inside a `ctx.runMutation`,
-  // i.e. with a non-null `nestedTxStorage` parent lock. The fired
-  // setTimeout callback must still acquire the global lock (not behave as
-  // if it were nested inside the long-gone parent transaction).
-  vi.useFakeTimers();
-  const t = convexTest(schema);
-  await t.mutation(api.scheduler.parentRunsMutationThatSchedules, {
-    body: "from-nested",
-  });
-  vi.runAllTimers();
-  await t.finishInProgressScheduledFunctions();
-  const messages = await t.query(internal.scheduler.list);
-  expect(messages.map((m: { body: string }) => m.body)).toEqual([
-    "from-nested",
-  ]);
-  vi.useRealTimers();
-});
-
-test("action can schedule a mutation and poll for its effect without finish*", async () => {
-  // Real timers: the scheduled mutation's setTimeout fires naturally
-  // while the action is awaiting its poll sleep. The action's runQuery
-  // releases the mutation lock between iterations, letting the scheduled
-  // mutation acquire it and commit.
-  const t = convexTest(schema);
-  await t.action(api.scheduler.actionSchedulesMutationAndPolls, {
-    body: "polled",
-  });
-  const messages = await t.query(internal.scheduler.list);
-  expect(messages.map((m: { body: string }) => m.body)).toEqual(["polled"]);
-});
-
-test("argument serialization", async () => {
-  vi.useFakeTimers();
-  const t = convexTest(schema);
-  await t.mutation(api.scheduler.mutationSchedulingAction, {
-    delayMs: 10000,
-    body: "through scheduler",
-    bigint: BigInt(1),
-  });
-  {
-    const jobs = await t.query(internal.scheduler.jobs);
-    expect(jobs).toMatchObject([
-      {
-        state: { kind: "pending" },
-        args: [{ body: "through scheduler", bigint: BigInt(1) }],
-      },
+    const messages = await t.query(internal.scheduler.list);
+    expect(messages.map((m: { body: string }) => m.body)).toEqual([
+      "B-parent-after",
+      "A-scheduled",
     ]);
-  }
+  });
 
-  vi.advanceTimersByTime(5000);
+  test("rollback cancels scheduled function", async () => {
+    const t = convexTest(schema);
+    await expect(
+      t.mutation(async (ctx) => {
+        await ctx.scheduler.runAfter(0, api.scheduler.add, {
+          body: "should-not-run",
+          author: "AI",
+        });
+        throw new Error("rollback");
+      }),
+    ).rejects.toThrowError(/rollback/);
 
-  {
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    const messages = await t.query(internal.scheduler.list);
+    expect(messages).toEqual([]);
     const jobs = await t.query(internal.scheduler.jobs);
-    expect(jobs).toMatchObject([{ state: { kind: "pending" } }]);
-  }
+    expect(jobs).toEqual([]);
+  });
 
-  vi.runAllTimers();
+  test("scheduling from a nested mutation still runs as top-level", async () => {
+    // Regression test: the schedule syscall runs inside a `ctx.runMutation`,
+    // i.e. with a non-null `nestedTxStorage` parent lock. The fired
+    // setTimeout callback must still acquire the global lock (not behave as
+    // if it were nested inside the long-gone parent transaction).
+    const t = convexTest(schema);
+    await t.mutation(api.scheduler.parentRunsMutationThatSchedules, {
+      body: "from-nested",
+    });
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+    const messages = await t.query(internal.scheduler.list);
+    expect(messages.map((m: { body: string }) => m.body)).toEqual([
+      "from-nested",
+    ]);
+  });
 
-  await t.finishInProgressScheduledFunctions();
+  test("argument serialization", async () => {
+    const t = convexTest(schema);
+    await t.mutation(api.scheduler.mutationSchedulingAction, {
+      delayMs: 10000,
+      body: "through scheduler",
+      bigint: BigInt(1),
+    });
+    {
+      const jobs = await t.query(internal.scheduler.jobs);
+      expect(jobs).toMatchObject([
+        {
+          state: { kind: "pending" },
+          args: [{ body: "through scheduler", bigint: BigInt(1) }],
+        },
+      ]);
+    }
 
-  const result = await t.query(internal.scheduler.list);
-  expect(result).toMatchObject([{ body: "through scheduler", author: "AI" }]);
-  {
-    const jobs = await t.query(internal.scheduler.jobs);
-    expect(jobs).toMatchObject([{ state: { kind: "success" } }]);
-  }
-  vi.useRealTimers();
+    vi.advanceTimersByTime(5000);
+
+    {
+      const jobs = await t.query(internal.scheduler.jobs);
+      expect(jobs).toMatchObject([{ state: { kind: "pending" } }]);
+    }
+
+    vi.runAllTimers();
+
+    await t.finishInProgressScheduledFunctions();
+
+    const result = await t.query(internal.scheduler.list);
+    expect(result).toMatchObject([{ body: "through scheduler", author: "AI" }]);
+    {
+      const jobs = await t.query(internal.scheduler.jobs);
+      expect(jobs).toMatchObject([{ state: { kind: "success" } }]);
+    }
+  });
+});
+
+describe("with real timers", () => {
+  test("action can schedule a mutation and poll for its effect without finish*", async () => {
+    // The scheduled mutation's setTimeout fires naturally while the action
+    // is awaiting its poll sleep. The action's runQuery releases the
+    // mutation lock between iterations, letting the scheduled mutation
+    // acquire it and commit.
+    const t = convexTest(schema);
+    await t.action(api.scheduler.actionSchedulesMutationAndPolls, {
+      body: "polled",
+    });
+    const messages = await t.query(internal.scheduler.list);
+    expect(messages.map((m: { body: string }) => m.body)).toEqual(["polled"]);
+  });
+
+  test("finishInProgressScheduledFunctions awaits work after the setTimeout fires", async () => {
+    const t = convexTest(schema);
+    await t.mutation(api.scheduler.mutationSchedulingAction, {
+      body: "real-timer",
+      delayMs: 0,
+    });
+    // Give the setTimeout(0) a chance to fire on the next event-loop tick.
+    await new Promise((r) => setTimeout(r, 10));
+    await t.finishInProgressScheduledFunctions();
+    const messages = await t.query(internal.scheduler.list);
+    expect(messages).toMatchObject([{ body: "real-timer", author: "AI" }]);
+  });
 });

--- a/convex/scheduler.ts
+++ b/convex/scheduler.ts
@@ -1,6 +1,6 @@
 import { v } from "convex/values";
 import { api } from "./_generated/api";
-import { action, internalQuery, mutation } from "./_generated/server";
+import { action, internalQuery, mutation, query } from "./_generated/server";
 import { Id } from "./_generated/dataModel";
 
 export const list = internalQuery({
@@ -137,5 +137,61 @@ export const selfSchedulingMutation = mutation({
       api.scheduler.selfSchedulingMutation,
       {},
     );
+  },
+});
+
+// Mutation that schedules two things: one now and one in the future
+export const scheduleNowAndLater = mutation({
+  args: {},
+  handler: async (ctx) => {
+    await ctx.scheduler.runAfter(0, api.scheduler.add, {
+      body: "immediate",
+      author: "AI",
+    });
+    await ctx.scheduler.runAfter(60000, api.scheduler.add, {
+      body: "delayed",
+      author: "AI",
+    });
+  },
+});
+
+// Mutation that calls another mutation via ctx.runMutation, which itself
+// schedules a function. Used to exercise the case where the schedule
+// syscall fires from inside a nested transaction.
+export const childSchedulesAdd = mutation({
+  args: { body: v.string() },
+  handler: async (ctx, { body }) => {
+    await ctx.scheduler.runAfter(0, api.scheduler.add, { body, author: "AI" });
+  },
+});
+
+export const parentRunsMutationThatSchedules = mutation({
+  args: { body: v.string() },
+  handler: async (ctx, { body }) => {
+    await ctx.runMutation(api.scheduler.childSchedulesAdd, { body });
+  },
+});
+
+// Action that schedules a mutation and then polls for its effect.
+// This pattern requires the scheduled mutation to be able to run while
+// the action is still executing — i.e. no deadlock waiting on the action
+// to return.
+export const actionSchedulesMutationAndPolls = action({
+  args: { body: v.string() },
+  handler: async (ctx, { body }) => {
+    await ctx.scheduler.runAfter(0, api.scheduler.add, { body, author: "AI" });
+    for (let i = 0; i < 100; i++) {
+      const messages = await ctx.runQuery(api.scheduler.listPublic, {});
+      if (messages.some((m) => m.body === body)) return;
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    throw new Error("polled too long without seeing scheduled mutation");
+  },
+});
+
+export const listPublic = query({
+  args: {},
+  handler: async (ctx) => {
+    return await ctx.db.query("messages").collect();
   },
 });

--- a/index.ts
+++ b/index.ts
@@ -1641,9 +1641,9 @@ function asyncSyscallImpl() {
                   }),
                 )
                 .finally(() => {
-                  scheduler.inFlightExecutions.delete(promise);
+                  scheduler.finish(promise);
                 });
-              scheduler.inFlightExecutions.add(promise);
+              scheduler.add(promise);
             },
             Math.max(0, tsInSecs * 1000 - Date.now()),
           );
@@ -2082,9 +2082,27 @@ function ensureGlobalProxy() {
 
 // Per-test scheduler state: tracks executions of scheduled functions that
 // have been fired (their setTimeout callback has run) but haven't yet
-// settled. `finish*ScheduledFunctions` awaits these.
+// settled.
 class Scheduler {
-  inFlightExecutions: Set<Promise<void>> = new Set();
+  private _inFlight: Set<Promise<void>> = new Set();
+
+  add(promise: Promise<void>) {
+    this._inFlight.add(promise);
+  }
+
+  finish(promise: Promise<void>) {
+    this._inFlight.delete(promise);
+  }
+
+  anyFunctionsRunning(): boolean {
+    return this._inFlight.size > 0;
+  }
+
+  async finishInProgressScheduledFunctions(): Promise<void> {
+    while (this._inFlight.size > 0) {
+      await Promise.all(this._inFlight);
+    }
+  }
 }
 
 class TransactionManager {
@@ -2718,12 +2736,6 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
       throw deserializeConvexErrorData(e);
     }
   };
-  const finishInProgressScheduledFunctions = async (): Promise<void> => {
-    const { inFlightExecutions } = getConvexGlobal().scheduler;
-    while (inFlightExecutions.size > 0) {
-      await Promise.all(inFlightExecutions);
-    }
-  };
   return {
     ...byType,
     ...byTypeWithPath,
@@ -2784,7 +2796,8 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
       return response;
     },
 
-    finishInProgressScheduledFunctions,
+    finishInProgressScheduledFunctions: (): Promise<void> =>
+      getConvexGlobal().scheduler.finishInProgressScheduledFunctions(),
 
     finishAllScheduledFunctions: async (
       advanceTimers: () => void,
@@ -2793,17 +2806,17 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
       // Wait for all scheduled functions to finish, advancing time in between
       // each function.
       // Stop after a fixed number of iterations to avoid infinite loops.
-      const { inFlightExecutions } = getConvexGlobal().scheduler;
+      const { scheduler } = getConvexGlobal();
       for (let i = 0; i < maxIterations; i++) {
         advanceTimers();
         // If no scheduled work fired, there's nothing left to wait for.
-        if (inFlightExecutions.size === 0) {
+        if (!scheduler.anyFunctionsRunning()) {
           return;
         }
         // Actions may use setTimeout internally (e.g. for delays).
         // Keep advancing timers while waiting so those can resolve.
         let done = false;
-        void finishInProgressScheduledFunctions().then(() => {
+        void scheduler.finishInProgressScheduledFunctions().then(() => {
           done = true;
         });
         const maxPumps = 10000;

--- a/index.ts
+++ b/index.ts
@@ -2799,7 +2799,7 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
         // Actions may use setTimeout internally (e.g. for delays).
         // Keep advancing timers while waiting so those can resolve.
         let done = false;
-        const drainPromise = finishInProgressScheduledFunctions().then(() => {
+        void finishInProgressScheduledFunctions().then(() => {
           done = true;
         });
         const maxPumps = 10000;
@@ -2822,7 +2822,6 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
             );
           }
         }
-        await drainPromise;
       }
       throw new Error(
         "finishAllScheduledFunctions: too many iterations. " +

--- a/index.ts
+++ b/index.ts
@@ -2780,9 +2780,6 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
       return response;
     },
 
-    // This is needed because when we execute functions
-    // we are performing dynamic `import`s, and those
-    // are real work that cannot be force-awaited.
     finishInProgressScheduledFunctions,
 
     finishAllScheduledFunctions: async (

--- a/index.ts
+++ b/index.ts
@@ -1571,76 +1571,40 @@ function asyncSyscallImpl() {
           scheduledTime: tsInSecs * 1000,
           state: { kind: "pending" },
         });
-        const componentPath = getCurrentComponentPath();
-        // Capture the current test's ConvexGlobal so the scheduled
-        // function callback (which runs via setTimeout, outside the
-        // original ALS context) uses the correct test state.
+        // Store the resolved function path so executeScheduledFunction
+        // can find the correct component (especially for function handles
+        // that resolve to a different component).
+        const sourceComponent = getCurrentComponentPath();
         const capturedGlobal = getConvexGlobal();
-        setTimeout(
-          // Scheduled functions run without auth context, even if
-          // they were scheduled from an authenticated function.
-          (() =>
-            convexGlobalStorage.run(capturedGlobal, () =>
-              authStorage.run(new AuthFake(), async () => {
-                const canceled = await withAuth().runInComponent(
-                  componentPath,
-                  async () => {
-                    const job = db.get("_scheduled_functions", jobId) as
-                      | ScheduledFunction
-                      | undefined;
-                    if (!job) return true;
-                    if (job.state.kind === "canceled") {
-                      return true;
-                    }
-                    if (job.state.kind !== "pending") {
-                      throw new Error(
-                        `\`convexTest\` invariant error: Unexpected scheduled function state when starting it: ${job.state.kind}`,
-                      );
-                    }
-                    db.patch("_scheduled_functions", jobId, {
-                      state: { kind: "inProgress" },
-                    });
-                    return false;
-                  },
-                );
-                if (canceled) {
-                  return;
-                }
-                try {
-                  await withAuth().fun(functionPath, parsedArgs);
-                } catch (error) {
-                  console.error(
-                    `Error when running scheduled function ${name}`,
-                    error,
-                  );
-                  await withAuth().runInComponent(componentPath, async () => {
-                    db.patch("_scheduled_functions", jobId, {
-                      state: { kind: "failed" },
-                      completedTime: Date.now(),
-                    });
-                  });
-                  db.jobFinished(jobId);
-                  return;
-                }
-                await withAuth().runInComponent(componentPath, async () => {
-                  const job = db.get(
-                    "_scheduled_functions",
-                    jobId,
-                  ) as ScheduledFunction;
-                  if (job.state.kind !== "inProgress") {
-                    throw new Error(
-                      `\`convexTest\` invariant error: Unexpected scheduled function state after it finished running: ${job.state.kind}`,
-                    );
-                  }
-                  db.patch("_scheduled_functions", jobId, {
-                    state: { kind: "success" },
-                  });
-                });
-                db.jobFinished(jobId);
-              }),
-            )) as () => void,
-          tsInSecs * 1000 - Date.now(),
+        capturedGlobal.scheduledFunctionPaths.set(
+          `${sourceComponent}:${jobId}`,
+          functionPath,
         );
+        // Fire execution via setTimeout so the clock model matches real
+        // Convex: jobs run when their scheduled time arrives. With fake
+        // timers this only fires when the user advances time. If the
+        // scheduling transaction rolls back, the row will be missing and
+        // the executor will skip it. Serialization with the parent and
+        // other jobs is provided by TransactionManager's global lock,
+        // which executeScheduledFunction acquires via mutationFromPath.
+        const delay = Math.max(0, tsInSecs * 1000 - Date.now());
+        // `nestedTxStorage.exit` clears the nested-mutation lock that the
+        // current async context carries (e.g. the fake mutation wrapping
+        // "1.0/actions/schedule"), so when the setTimeout callback fires
+        // it does so as a top-level execution and properly acquires the
+        // global lock instead of treating itself as a nested mutation.
+        nestedTxStorage.exit(() => {
+          setTimeout(() => {
+            const promise = executeScheduledFunction(
+              capturedGlobal,
+              sourceComponent,
+              jobId,
+            ).finally(() => {
+              capturedGlobal.inFlightScheduledExecutions.delete(promise);
+            });
+            capturedGlobal.inFlightScheduledExecutions.add(promise);
+          }, delay);
+        });
         return JSON.stringify(convexToJson(jobId));
       }
       case "1.0/actions/cancel_job": {
@@ -1766,33 +1730,139 @@ async function blobSha(blob: Blob) {
   return btoa(String.fromCharCode(...hashArray));
 }
 
-async function waitForInProgressScheduledFunctions(): Promise<boolean> {
-  let hadScheduledFunctions = false;
-  for (const componentPath of Object.keys(getConvexGlobal().components)) {
-    const inProgressJobs = (await withAuth().runInComponent(
+/**
+ * Execute a single scheduled function by its job ID and component path.
+ * Handles state transitions, error handling, and job completion notification.
+ */
+async function executeScheduledFunction(
+  capturedGlobal: ConvexGlobal,
+  sourceComponentPath: string,
+  jobId: GenericId<"_scheduled_functions">,
+): Promise<void> {
+  await convexGlobalStorage.run(capturedGlobal, () =>
+    authStorage.run(new AuthFake(), async () => {
+      const db = getDbForComponent(sourceComponentPath);
+      // Acquire the mutation lock and check whether the job still exists
+      // and is pending. Doing this inside runInComponent ensures the
+      // scheduling transaction has fully committed (or rolled back) before
+      // we observe the row.
+      const startResult = (await withAuth().runInComponent(
+        sourceComponentPath,
+        async () => {
+          const j = db.get(
+            "_scheduled_functions",
+            jobId,
+          ) as ScheduledFunction | null;
+          if (!j) {
+            return { skip: true as const };
+          }
+          if (j.state.kind === "canceled") {
+            return { skip: true as const };
+          }
+          if (j.state.kind !== "pending") {
+            throw new Error(
+              `\`convexTest\` invariant error: Unexpected scheduled function state when starting it: ${j.state.kind}`,
+            );
+          }
+          db.patch("_scheduled_functions", jobId, {
+            state: { kind: "inProgress" },
+          });
+          return { skip: false as const, job: j };
+        },
+      )) as { skip: true } | { skip: false; job: ScheduledFunction };
+      if (startResult.skip) {
+        capturedGlobal.scheduledFunctionPaths.delete(
+          `${sourceComponentPath}:${jobId}`,
+        );
+        return;
+      }
+      const job = startResult.job;
+      // Use the resolved function path if available (needed for function
+      // handles that target a different component). Fall back to
+      // reconstructing from the source component and stored name.
+      const functionPath: FunctionPath =
+        capturedGlobal.scheduledFunctionPaths.get(
+          `${sourceComponentPath}:${jobId}`,
+        ) ?? {
+          componentPath: sourceComponentPath,
+          udfPath: String(job.name),
+        };
+      const parsedArgs = (job.args as any)[0];
+      try {
+        await withAuth().fun(functionPath, parsedArgs);
+      } catch (error) {
+        console.error(
+          `Error when running scheduled function ${job.name}`,
+          error,
+        );
+        await withAuth().runInComponent(sourceComponentPath, async () => {
+          db.patch("_scheduled_functions", jobId, {
+            state: { kind: "failed" },
+            completedTime: Date.now(),
+          });
+        });
+        db.jobFinished(jobId);
+        return;
+      }
+      await withAuth().runInComponent(sourceComponentPath, async () => {
+        const updatedJob = db.get(
+          "_scheduled_functions",
+          jobId,
+        ) as ScheduledFunction;
+        if (updatedJob.state.kind !== "inProgress") {
+          throw new Error(
+            `\`convexTest\` invariant error: Unexpected scheduled function state after it finished running: ${updatedJob.state.kind}`,
+          );
+        }
+        db.patch("_scheduled_functions", jobId, {
+          state: { kind: "success" },
+        });
+      });
+      db.jobFinished(jobId);
+    }),
+  );
+}
+
+/**
+ * Find the earliest pending scheduled function across all components.
+ * Returns null if no pending functions exist.
+ */
+async function findEarliestPendingFunction(
+  convexGlobal: ConvexGlobal,
+): Promise<{
+  componentPath: string;
+  jobId: GenericId<"_scheduled_functions">;
+  scheduledTime: number;
+} | null> {
+  let earliest: {
+    componentPath: string;
+    jobId: GenericId<"_scheduled_functions">;
+    scheduledTime: number;
+  } | null = null;
+
+  for (const componentPath of Object.keys(convexGlobal.components)) {
+    const pendingJobs = (await withAuth().runInComponent(
       componentPath,
       async (ctx) => {
         return (
           await ctx.db.system.query("_scheduled_functions").collect()
-        ).filter((job: ScheduledFunction) => job.state.kind === "inProgress");
+        ).filter((job: ScheduledFunction) => job.state.kind === "pending");
       },
     )) as ScheduledFunction[];
-    let numRemaining = inProgressJobs.length;
-    if (numRemaining === 0) {
-      continue;
-    }
-    hadScheduledFunctions = true;
 
-    await new Promise<void>((resolve) => {
-      getDbForComponent(componentPath).jobListener = () => {
-        numRemaining -= 1;
-        if (numRemaining === 0) {
-          resolve();
-        }
-      };
-    });
+    for (const job of pendingJobs) {
+      const scheduledTime = job.scheduledTime;
+      if (earliest === null || scheduledTime < earliest.scheduledTime) {
+        earliest = {
+          componentPath,
+          jobId: job._id,
+          scheduledTime,
+        };
+      }
+    }
   }
-  return hadScheduledFunctions;
+
+  return earliest;
 }
 
 export type TestConvex<SchemaDef extends SchemaDefinition<any, boolean>> =
@@ -1909,28 +1979,33 @@ export type TestConvexForDataModel<DataModel extends GenericDataModel> = {
   fetch(pathQueryFragment: string, init?: RequestInit): Promise<Response>;
 
   /**
-   * Wait for all scheduled functions currently in the "inProgress" state
-   * to either finish successfully or fail.
+   * Run all pending scheduled functions whose scheduled time has passed
+   * (i.e. `scheduledTime <= Date.now()`), one at a time, in order of
+   * scheduled time. Also waits for any already-in-progress functions.
    *
-   * Use in combination with `vi.useFakeTimers()` and `vi.runAllTimers()`
-   * to control precisely the execution of scheduled functions.
+   * Use in combination with `vi.useFakeTimers()` and
+   * `vi.advanceTimersByTime(ms)` to control the execution of scheduled
+   * functions.
    *
    * Typically:
-   * 1. Use `vi.runAllTimers()` or similar to advance
-   *   time such that a function is scheduled.
-   * 2. Use `finishInProgressScheduledFunctions()` to wait for the function
+   * 1. Use `vi.advanceTimersByTime(ms)` to advance time past when a
+   *    function is scheduled.
+   * 2. Use `finishInProgressScheduledFunctions()` to run and wait for
+   *    those functions.
    */
   finishInProgressScheduledFunctions: () => Promise<void>;
 
   /**
-   * Wait for all currently scheduled functions and any functions they
-   * schedule to either finish successfully or fail.
+   * Run all currently pending scheduled functions and any functions they
+   * schedule, advancing time as needed.
+   *
+   * Functions are executed one at a time in order of scheduled time.
+   * Time is advanced to each function's scheduled time before executing it.
    *
    * Use in combination with `vi.useFakeTimers()` to test scheduled functions.
    *
    * @param advanceTimers Function that advances timers,
-   *   usually `vi.runAllTimers`. This function will be called in a loop
-   *   with `finishInProgressScheduledFunctions()`.
+   *   usually `vi.runAllTimers`.
    */
   finishAllScheduledFunctions: (advanceTimers: () => void) => Promise<void>;
 };
@@ -2066,6 +2141,15 @@ type ConvexGlobal = {
   syscall: (op: string, args: any) => any;
   asyncSyscall: (op: string, args: any) => Promise<any>;
   jsSyscall: (op: string, args: any) => Promise<any>;
+  // Maps "sourceComponentPath:jobId" to their resolved target function paths.
+  // Needed because function handles may resolve to a different component
+  // than the one where the job is stored. Keyed by component+jobId since
+  // different components can generate the same document IDs.
+  scheduledFunctionPaths: Map<string, FunctionPath>;
+  // Promises for scheduled-function executions that have started (their
+  // setTimeout fired) but not yet finished. finish*ScheduledFunctions
+  // awaits these so callers can block until in-flight work settles.
+  inFlightScheduledExecutions: Set<Promise<void>>;
 };
 
 function getConvexGlobal(): ConvexGlobal {
@@ -2291,6 +2375,8 @@ export function convexTest<Schema extends GenericSchema>(
     syscall: syscallImpl(),
     asyncSyscall: asyncSyscallImpl(),
     jsSyscall: jsSyscallImpl(),
+    scheduledFunctionPaths: new Map(),
+    inFlightScheduledExecutions: new Set(),
   };
   ensureGlobalProxy();
 
@@ -2790,54 +2876,61 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
       return response;
     },
 
-    // This is needed because when we execute functions
-    // we are performing dynamic `import`s, and those
-    // are real work that cannot be force-awaited.
     finishInProgressScheduledFunctions: async (): Promise<void> => {
-      await waitForInProgressScheduledFunctions();
+      // Scheduled functions are auto-fired by the setTimeout queued at
+      // schedule time, so this just waits for any in-flight executions
+      // to settle. It does NOT advance timers or trigger pending jobs
+      // whose scheduled time has not yet arrived.
+      const convexGlobal = getConvexGlobal();
+      while (convexGlobal.inFlightScheduledExecutions.size > 0) {
+        await Promise.all(convexGlobal.inFlightScheduledExecutions);
+      }
     },
 
     finishAllScheduledFunctions: async (
       advanceTimers: () => void,
       maxIterations: number = 100,
     ): Promise<void> => {
-      // Wait for all scheduled functions to finish, advancing time in between
-      // each function.
-      // Stop after a fixed number of iterations to avoid infinite loops.
+      const convexGlobal = getConvexGlobal();
+      // Repeatedly advance timers and drain in-flight executions until
+      // there's nothing pending or running. Each iteration fires any
+      // scheduler setTimeouts whose scheduled time has arrived; their
+      // executions register Promises in inFlightScheduledExecutions which
+      // we then await. A scheduled function may itself schedule more work,
+      // so we loop until quiescent.
       for (let i = 0; i < maxIterations; i++) {
         advanceTimers();
-        // Actions may use setTimeout internally (e.g. for delays).
-        // Keep advancing timers while waiting so those can resolve.
-        let done = false;
-        const waitPromise = waitForInProgressScheduledFunctions().then(
-          (had) => {
-            done = true;
-            return had;
-          },
-        );
+        // Let any setTimeout callbacks that just fired register their
+        // execution Promises before we check the set.
+        await new Promise<void>((r) => {
+          const { port1, port2 } = new MessageChannel();
+          port2.onmessage = () => r();
+          port1.postMessage(null);
+        });
+        if (
+          convexGlobal.inFlightScheduledExecutions.size === 0 &&
+          (await findEarliestPendingFunction(convexGlobal)) === null
+        ) {
+          return;
+        }
+        // Pump timers while waiting so that internal setTimeouts inside
+        // executing actions can resolve.
         const maxPumps = 10000;
-        for (let pump = 0; pump < maxPumps && !done; pump++) {
+        for (let pump = 0; pump < maxPumps; pump++) {
+          if (convexGlobal.inFlightScheduledExecutions.size === 0) break;
           advanceTimers();
-          // Yield through a full event loop iteration so that dynamic
-          // import() calls (used to load function modules) can resolve.
-          // Using MessageChannel to post to the macrotask queue —
-          // it is not faked by vitest and not removed by edge-runtime.
           await new Promise<void>((r) => {
             const { port1, port2 } = new MessageChannel();
             port2.onmessage = () => r();
             port1.postMessage(null);
           });
-          if (pump === maxPumps - 1 && !done) {
+          if (pump === maxPumps - 1) {
             throw new Error(
               "finishAllScheduledFunctions: scheduled function did not " +
                 `complete after ${maxPumps} timer pumps. ` +
                 "Does an action have an unresolvable setTimeout or infinite loop?",
             );
           }
-        }
-        const hadScheduledFunctions = await waitPromise;
-        if (!hadScheduledFunctions) {
-          return;
         }
       }
       throw new Error(

--- a/index.ts
+++ b/index.ts
@@ -1570,7 +1570,7 @@ function asyncSyscallImpl() {
         // function callback (which runs via setTimeout, outside the
         // original ALS context) uses the correct test state.
         const capturedGlobal = getConvexGlobal();
-        const transactionManager = capturedGlobal.transactionManager;
+        const scheduler = capturedGlobal.scheduler;
         // Queue the setTimeout outside any nested-mutation ALS context so
         // the scheduled function starts as a fresh top-level execution
         // rather than inheriting a stale parent lock.
@@ -1641,11 +1641,9 @@ function asyncSyscallImpl() {
                   }),
                 )
                 .finally(() => {
-                  transactionManager.inFlightScheduledExecutions.delete(
-                    promise,
-                  );
+                  scheduler.inFlightExecutions.delete(promise);
                 });
-              transactionManager.inFlightScheduledExecutions.add(promise);
+              scheduler.inFlightExecutions.add(promise);
             },
             Math.max(0, tsInSecs * 1000 - Date.now()),
           );
@@ -2044,6 +2042,7 @@ const executionContextStorage = new AsyncLocalStorage<ExecutionContext>();
 type ConvexGlobal = {
   components: Record<string, ComponentInfo>;
   transactionManager: TransactionManager;
+  scheduler: Scheduler;
   syscall: (op: string, args: any) => any;
   asyncSyscall: (op: string, args: any) => Promise<any>;
   jsSyscall: (op: string, args: any) => Promise<any>;
@@ -2081,6 +2080,13 @@ function ensureGlobalProxy() {
   } as ConvexGlobal;
 }
 
+// Per-test scheduler state: tracks executions of scheduled functions that
+// have been fired (their setTimeout callback has run) but haven't yet
+// settled. `finish*ScheduledFunctions` awaits these.
+class Scheduler {
+  inFlightExecutions: Set<Promise<void>> = new Set();
+}
+
 class TransactionManager {
   // The DatabaseFake is used in the Convex global,
   // and so it restricts `convexTest` to run one function
@@ -2091,9 +2097,6 @@ class TransactionManager {
   private _markTransactionDone: (() => void) | null = null;
   private _metricsTracker: TransactionMetricsTracker | null = null;
   private _limitsConfig: Partial<TransactionMetrics> | boolean;
-  // Scheduled-function executions currently in flight. Callers can await
-  // these to block until in-flight scheduled work settles.
-  inFlightScheduledExecutions: Set<Promise<void>> = new Set();
 
   constructor(limitsConfig: Partial<TransactionMetrics> | boolean = false) {
     this._limitsConfig = limitsConfig;
@@ -2272,6 +2275,7 @@ export function convexTest<Schema extends GenericSchema>(
       },
     },
     transactionManager: new TransactionManager(limitsConfig),
+    scheduler: new Scheduler(),
     syscall: syscallImpl(),
     asyncSyscall: asyncSyscallImpl(),
     jsSyscall: jsSyscallImpl(),
@@ -2715,9 +2719,9 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
     }
   };
   const finishInProgressScheduledFunctions = async (): Promise<void> => {
-    const tm = getTransactionManager();
-    while (tm.inFlightScheduledExecutions.size > 0) {
-      await Promise.all(tm.inFlightScheduledExecutions);
+    const { inFlightExecutions } = getConvexGlobal().scheduler;
+    while (inFlightExecutions.size > 0) {
+      await Promise.all(inFlightExecutions);
     }
   };
   return {
@@ -2789,11 +2793,11 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
       // Wait for all scheduled functions to finish, advancing time in between
       // each function.
       // Stop after a fixed number of iterations to avoid infinite loops.
-      const tm = getTransactionManager();
+      const { inFlightExecutions } = getConvexGlobal().scheduler;
       for (let i = 0; i < maxIterations; i++) {
         advanceTimers();
         // If no scheduled work fired, there's nothing left to wait for.
-        if (tm.inFlightScheduledExecutions.size === 0) {
+        if (inFlightExecutions.size === 0) {
           return;
         }
         // Actions may use setTimeout internally (e.g. for delays).

--- a/index.ts
+++ b/index.ts
@@ -153,8 +153,6 @@ class DatabaseFake {
   private _nextDocId: number = 10000;
   private _lastCreationTime: number = 0;
   private _queryResults: Record<QueryId, Array<GenericDocument>> = {};
-  // TODO: Make this more robust and cleaner
-  jobListener: (jobId: string) => void = () => {};
   // Pending writes for each level of transaction nesting.
   // Whenever a child mutation begins, a new level is created for all
   // components.
@@ -785,10 +783,6 @@ class DatabaseFake {
       results = results.slice(0, limit);
     }
     return results;
-  }
-
-  jobFinished(jobId: string) {
-    this.jobListener(jobId);
   }
 
   vectorSearch(
@@ -1571,39 +1565,90 @@ function asyncSyscallImpl() {
           scheduledTime: tsInSecs * 1000,
           state: { kind: "pending" },
         });
-        // Store the resolved function path so executeScheduledFunction
-        // can find the correct component (especially for function handles
-        // that resolve to a different component).
-        const sourceComponent = getCurrentComponentPath();
+        const componentPath = getCurrentComponentPath();
+        // Capture the current test's ConvexGlobal so the scheduled
+        // function callback (which runs via setTimeout, outside the
+        // original ALS context) uses the correct test state.
         const capturedGlobal = getConvexGlobal();
-        capturedGlobal.scheduledFunctionPaths.set(
-          `${sourceComponent}:${jobId}`,
-          functionPath,
-        );
-        // Fire execution via setTimeout so the clock model matches real
-        // Convex: jobs run when their scheduled time arrives. With fake
-        // timers this only fires when the user advances time. If the
-        // scheduling transaction rolls back, the row will be missing and
-        // the executor will skip it. Serialization with the parent and
-        // other jobs is provided by TransactionManager's global lock,
-        // which executeScheduledFunction acquires via mutationFromPath.
-        const delay = Math.max(0, tsInSecs * 1000 - Date.now());
-        // `nestedTxStorage.exit` clears the nested-mutation lock that the
-        // current async context carries (e.g. the fake mutation wrapping
-        // "1.0/actions/schedule"), so when the setTimeout callback fires
-        // it does so as a top-level execution and properly acquires the
-        // global lock instead of treating itself as a nested mutation.
+        const transactionManager = capturedGlobal.transactionManager;
+        // Queue the setTimeout outside any nested-mutation ALS context so
+        // the scheduled function starts as a fresh top-level execution
+        // rather than inheriting a stale parent lock.
         nestedTxStorage.exit(() => {
-          setTimeout(() => {
-            const promise = executeScheduledFunction(
-              capturedGlobal,
-              sourceComponent,
-              jobId,
-            ).finally(() => {
-              capturedGlobal.inFlightScheduledExecutions.delete(promise);
-            });
-            capturedGlobal.inFlightScheduledExecutions.add(promise);
-          }, delay);
+          setTimeout(
+            () => {
+              // Scheduled functions run without auth context, even if
+              // they were scheduled from an authenticated function.
+              const promise = convexGlobalStorage
+                .run(capturedGlobal, () =>
+                  authStorage.run(new AuthFake(), async () => {
+                    const canceled = await withAuth().runInComponent(
+                      componentPath,
+                      async () => {
+                        const job = db.get("_scheduled_functions", jobId) as
+                          | ScheduledFunction
+                          | undefined;
+                        if (!job) return true;
+                        if (job.state.kind === "canceled") {
+                          return true;
+                        }
+                        if (job.state.kind !== "pending") {
+                          throw new Error(
+                            `\`convexTest\` invariant error: Unexpected scheduled function state when starting it: ${job.state.kind}`,
+                          );
+                        }
+                        db.patch("_scheduled_functions", jobId, {
+                          state: { kind: "inProgress" },
+                        });
+                        return false;
+                      },
+                    );
+                    if (canceled) {
+                      return;
+                    }
+                    try {
+                      await withAuth().fun(functionPath, parsedArgs);
+                    } catch (error) {
+                      console.error(
+                        `Error when running scheduled function ${name}`,
+                        error,
+                      );
+                      await withAuth().runInComponent(
+                        componentPath,
+                        async () => {
+                          db.patch("_scheduled_functions", jobId, {
+                            state: { kind: "failed" },
+                            completedTime: Date.now(),
+                          });
+                        },
+                      );
+                      return;
+                    }
+                    await withAuth().runInComponent(componentPath, async () => {
+                      const job = db.get(
+                        "_scheduled_functions",
+                        jobId,
+                      ) as ScheduledFunction;
+                      if (job.state.kind !== "inProgress") {
+                        throw new Error(
+                          `\`convexTest\` invariant error: Unexpected scheduled function state after it finished running: ${job.state.kind}`,
+                        );
+                      }
+                      db.patch("_scheduled_functions", jobId, {
+                        state: { kind: "success" },
+                      });
+                    });
+                  }),
+                )
+                .finally(() => {
+                  transactionManager.inFlightScheduledExecutions.delete(
+                    promise,
+                  );
+                });
+              transactionManager.inFlightScheduledExecutions.add(promise);
+            },
+            Math.max(0, tsInSecs * 1000 - Date.now()),
+          );
         });
         return JSON.stringify(convexToJson(jobId));
       }
@@ -1730,141 +1775,6 @@ async function blobSha(blob: Blob) {
   return btoa(String.fromCharCode(...hashArray));
 }
 
-/**
- * Execute a single scheduled function by its job ID and component path.
- * Handles state transitions, error handling, and job completion notification.
- */
-async function executeScheduledFunction(
-  capturedGlobal: ConvexGlobal,
-  sourceComponentPath: string,
-  jobId: GenericId<"_scheduled_functions">,
-): Promise<void> {
-  await convexGlobalStorage.run(capturedGlobal, () =>
-    authStorage.run(new AuthFake(), async () => {
-      const db = getDbForComponent(sourceComponentPath);
-      // Acquire the mutation lock and check whether the job still exists
-      // and is pending. Doing this inside runInComponent ensures the
-      // scheduling transaction has fully committed (or rolled back) before
-      // we observe the row.
-      const startResult = (await withAuth().runInComponent(
-        sourceComponentPath,
-        async () => {
-          const j = db.get(
-            "_scheduled_functions",
-            jobId,
-          ) as ScheduledFunction | null;
-          if (!j) {
-            return { skip: true as const };
-          }
-          if (j.state.kind === "canceled") {
-            return { skip: true as const };
-          }
-          if (j.state.kind !== "pending") {
-            throw new Error(
-              `\`convexTest\` invariant error: Unexpected scheduled function state when starting it: ${j.state.kind}`,
-            );
-          }
-          db.patch("_scheduled_functions", jobId, {
-            state: { kind: "inProgress" },
-          });
-          return { skip: false as const, job: j };
-        },
-      )) as { skip: true } | { skip: false; job: ScheduledFunction };
-      if (startResult.skip) {
-        capturedGlobal.scheduledFunctionPaths.delete(
-          `${sourceComponentPath}:${jobId}`,
-        );
-        return;
-      }
-      const job = startResult.job;
-      // Use the resolved function path if available (needed for function
-      // handles that target a different component). Fall back to
-      // reconstructing from the source component and stored name.
-      const functionPath: FunctionPath =
-        capturedGlobal.scheduledFunctionPaths.get(
-          `${sourceComponentPath}:${jobId}`,
-        ) ?? {
-          componentPath: sourceComponentPath,
-          udfPath: String(job.name),
-        };
-      const parsedArgs = (job.args as any)[0];
-      try {
-        await withAuth().fun(functionPath, parsedArgs);
-      } catch (error) {
-        console.error(
-          `Error when running scheduled function ${job.name}`,
-          error,
-        );
-        await withAuth().runInComponent(sourceComponentPath, async () => {
-          db.patch("_scheduled_functions", jobId, {
-            state: { kind: "failed" },
-            completedTime: Date.now(),
-          });
-        });
-        db.jobFinished(jobId);
-        return;
-      }
-      await withAuth().runInComponent(sourceComponentPath, async () => {
-        const updatedJob = db.get(
-          "_scheduled_functions",
-          jobId,
-        ) as ScheduledFunction;
-        if (updatedJob.state.kind !== "inProgress") {
-          throw new Error(
-            `\`convexTest\` invariant error: Unexpected scheduled function state after it finished running: ${updatedJob.state.kind}`,
-          );
-        }
-        db.patch("_scheduled_functions", jobId, {
-          state: { kind: "success" },
-        });
-      });
-      db.jobFinished(jobId);
-    }),
-  );
-}
-
-/**
- * Find the earliest pending scheduled function across all components.
- * Returns null if no pending functions exist.
- */
-async function findEarliestPendingFunction(
-  convexGlobal: ConvexGlobal,
-): Promise<{
-  componentPath: string;
-  jobId: GenericId<"_scheduled_functions">;
-  scheduledTime: number;
-} | null> {
-  let earliest: {
-    componentPath: string;
-    jobId: GenericId<"_scheduled_functions">;
-    scheduledTime: number;
-  } | null = null;
-
-  for (const componentPath of Object.keys(convexGlobal.components)) {
-    const pendingJobs = (await withAuth().runInComponent(
-      componentPath,
-      async (ctx) => {
-        return (
-          await ctx.db.system.query("_scheduled_functions").collect()
-        ).filter((job: ScheduledFunction) => job.state.kind === "pending");
-      },
-    )) as ScheduledFunction[];
-
-    for (const job of pendingJobs) {
-      const scheduledTime = job.scheduledTime;
-      if (earliest === null || scheduledTime < earliest.scheduledTime) {
-        earliest = {
-          componentPath,
-          jobId: job._id,
-          scheduledTime,
-        };
-      }
-    }
-  }
-
-  return earliest;
-}
-
 export type TestConvex<SchemaDef extends SchemaDefinition<any, boolean>> =
   TestConvexForDataModelAndIdentity<DataModelFromSchemaDefinition<SchemaDef>>;
 
@@ -1979,33 +1889,29 @@ export type TestConvexForDataModel<DataModel extends GenericDataModel> = {
   fetch(pathQueryFragment: string, init?: RequestInit): Promise<Response>;
 
   /**
-   * Run all pending scheduled functions whose scheduled time has passed
-   * (i.e. `scheduledTime <= Date.now()`), one at a time, in order of
-   * scheduled time. Also waits for any already-in-progress functions.
+   * Wait for all scheduled functions currently in the "inProgress" state
+   * to either finish successfully or fail.
    *
-   * Use in combination with `vi.useFakeTimers()` and
-   * `vi.advanceTimersByTime(ms)` to control the execution of scheduled
-   * functions.
+   * Use in combination with `vi.useFakeTimers()` and `vi.runAllTimers()`
+   * to control precisely the execution of scheduled functions.
    *
    * Typically:
-   * 1. Use `vi.advanceTimersByTime(ms)` to advance time past when a
-   *    function is scheduled.
-   * 2. Use `finishInProgressScheduledFunctions()` to run and wait for
-   *    those functions.
+   * 1. Use `vi.runAllTimers()` or similar to advance
+   *   time such that a function is scheduled.
+   * 2. Use `finishInProgressScheduledFunctions()` to wait for the function
+   *    to finish.
    */
   finishInProgressScheduledFunctions: () => Promise<void>;
 
   /**
-   * Run all currently pending scheduled functions and any functions they
-   * schedule, advancing time as needed.
-   *
-   * Functions are executed one at a time in order of scheduled time.
-   * Time is advanced to each function's scheduled time before executing it.
+   * Wait for all currently scheduled functions and any functions they
+   * schedule to either finish successfully or fail.
    *
    * Use in combination with `vi.useFakeTimers()` to test scheduled functions.
    *
    * @param advanceTimers Function that advances timers,
-   *   usually `vi.runAllTimers`.
+   *   usually `vi.runAllTimers`. This function will be called in a loop
+   *   with `finishInProgressScheduledFunctions()`.
    */
   finishAllScheduledFunctions: (advanceTimers: () => void) => Promise<void>;
 };
@@ -2141,15 +2047,6 @@ type ConvexGlobal = {
   syscall: (op: string, args: any) => any;
   asyncSyscall: (op: string, args: any) => Promise<any>;
   jsSyscall: (op: string, args: any) => Promise<any>;
-  // Maps "sourceComponentPath:jobId" to their resolved target function paths.
-  // Needed because function handles may resolve to a different component
-  // than the one where the job is stored. Keyed by component+jobId since
-  // different components can generate the same document IDs.
-  scheduledFunctionPaths: Map<string, FunctionPath>;
-  // Promises for scheduled-function executions that have started (their
-  // setTimeout fired) but not yet finished. finish*ScheduledFunctions
-  // awaits these so callers can block until in-flight work settles.
-  inFlightScheduledExecutions: Set<Promise<void>>;
 };
 
 function getConvexGlobal(): ConvexGlobal {
@@ -2194,6 +2091,9 @@ class TransactionManager {
   private _markTransactionDone: (() => void) | null = null;
   private _metricsTracker: TransactionMetricsTracker | null = null;
   private _limitsConfig: Partial<TransactionMetrics> | boolean;
+  // Scheduled-function executions currently in flight. Callers can await
+  // these to block until in-flight scheduled work settles.
+  inFlightScheduledExecutions: Set<Promise<void>> = new Set();
 
   constructor(limitsConfig: Partial<TransactionMetrics> | boolean = false) {
     this._limitsConfig = limitsConfig;
@@ -2375,8 +2275,6 @@ export function convexTest<Schema extends GenericSchema>(
     syscall: syscallImpl(),
     asyncSyscall: asyncSyscallImpl(),
     jsSyscall: jsSyscallImpl(),
-    scheduledFunctionPaths: new Map(),
-    inFlightScheduledExecutions: new Set(),
   };
   ensureGlobalProxy();
 
@@ -2816,6 +2714,12 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
       throw deserializeConvexErrorData(e);
     }
   };
+  const finishInProgressScheduledFunctions = async (): Promise<void> => {
+    const tm = getTransactionManager();
+    while (tm.inFlightScheduledExecutions.size > 0) {
+      await Promise.all(tm.inFlightScheduledExecutions);
+    }
+  };
   return {
     ...byType,
     ...byTypeWithPath,
@@ -2876,55 +2780,44 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
       return response;
     },
 
-    finishInProgressScheduledFunctions: async (): Promise<void> => {
-      // Scheduled functions are auto-fired by the setTimeout queued at
-      // schedule time, so this just waits for any in-flight executions
-      // to settle. It does NOT advance timers or trigger pending jobs
-      // whose scheduled time has not yet arrived.
-      const convexGlobal = getConvexGlobal();
-      while (convexGlobal.inFlightScheduledExecutions.size > 0) {
-        await Promise.all(convexGlobal.inFlightScheduledExecutions);
-      }
-    },
+    // This is needed because when we execute functions
+    // we are performing dynamic `import`s, and those
+    // are real work that cannot be force-awaited.
+    finishInProgressScheduledFunctions,
 
     finishAllScheduledFunctions: async (
       advanceTimers: () => void,
       maxIterations: number = 100,
     ): Promise<void> => {
-      const convexGlobal = getConvexGlobal();
-      // Repeatedly advance timers and drain in-flight executions until
-      // there's nothing pending or running. Each iteration fires any
-      // scheduler setTimeouts whose scheduled time has arrived; their
-      // executions register Promises in inFlightScheduledExecutions which
-      // we then await. A scheduled function may itself schedule more work,
-      // so we loop until quiescent.
+      // Wait for all scheduled functions to finish, advancing time in between
+      // each function.
+      // Stop after a fixed number of iterations to avoid infinite loops.
+      const tm = getTransactionManager();
       for (let i = 0; i < maxIterations; i++) {
         advanceTimers();
-        // Let any setTimeout callbacks that just fired register their
-        // execution Promises before we check the set.
-        await new Promise<void>((r) => {
-          const { port1, port2 } = new MessageChannel();
-          port2.onmessage = () => r();
-          port1.postMessage(null);
-        });
-        if (
-          convexGlobal.inFlightScheduledExecutions.size === 0 &&
-          (await findEarliestPendingFunction(convexGlobal)) === null
-        ) {
+        // If no scheduled work fired, there's nothing left to wait for.
+        if (tm.inFlightScheduledExecutions.size === 0) {
           return;
         }
-        // Pump timers while waiting so that internal setTimeouts inside
-        // executing actions can resolve.
+        // Actions may use setTimeout internally (e.g. for delays).
+        // Keep advancing timers while waiting so those can resolve.
+        let done = false;
+        const drainPromise = finishInProgressScheduledFunctions().then(() => {
+          done = true;
+        });
         const maxPumps = 10000;
-        for (let pump = 0; pump < maxPumps; pump++) {
-          if (convexGlobal.inFlightScheduledExecutions.size === 0) break;
+        for (let pump = 0; pump < maxPumps && !done; pump++) {
           advanceTimers();
+          // Yield through a full event loop iteration so that dynamic
+          // import() calls (used to load function modules) can resolve.
+          // Using MessageChannel to post to the macrotask queue —
+          // it is not faked by vitest and not removed by edge-runtime.
           await new Promise<void>((r) => {
             const { port1, port2 } = new MessageChannel();
             port2.onmessage = () => r();
             port1.postMessage(null);
           });
-          if (pump === maxPumps - 1) {
+          if (pump === maxPumps - 1 && !done) {
             throw new Error(
               "finishAllScheduledFunctions: scheduled function did not " +
                 `complete after ${maxPumps} timer pumps. ` +
@@ -2932,6 +2825,7 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
             );
           }
         }
+        await drainPromise;
       }
       throw new Error(
         "finishAllScheduledFunctions: too many iterations. " +


### PR DESCRIPTION
Currently a scheduled function uses setTimeout, which can fire mid-way through a transaction if real timers are used.

And scheduling multiple functions can also race. This is because they detect the current global transaction lock and infer they're a nested transaction call.

This PR waits until the nested transaction has finished before starting the next scheduled function, allowing it to use the global transaction lock to serialize scheduled mutations, regardless of where they're scheduled from or whether real timers are used or not.

Fixes #112

Closes #82