### PR TITLE
Enforce single paginate() call per function execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Enforce the Convex runtime rule that a single function execution may only
+  run one paginated query (`.paginate()`). Calling it more than once now
+  throws, catching a production-only failure that previously passed silently
+  in tests.
+
 ## 0.0.53
 
 - Support scheduled functions correctly with or without fake timers,

--- a/convex/pagination.test.ts
+++ b/convex/pagination.test.ts
@@ -396,3 +396,60 @@ test("paginate with deletes and composite index", async () => {
   expect(page3).toMatchObject([{ author: "jordan", body: "hello4" }]);
   expect(isDone3).toEqual(true);
 });
+
+const paginateOnce = (ctx: any) =>
+  ctx.db.query("messages").paginate({ cursor: null, numItems: 10 });
+
+test("multiple paginate calls in one function execution throw", async () => {
+  const t = convexTest({ schema });
+  await t.run(async (ctx) => {
+    await ctx.db.insert("messages", { author: "sarah", body: "hello" });
+  });
+  await expect(
+    t.query(async (ctx) => {
+      await paginateOnce(ctx);
+      await paginateOnce(ctx);
+    }),
+  ).rejects.toThrow(/single paginated query/);
+});
+
+test("a single paginate call is allowed", async () => {
+  const t = convexTest({ schema });
+  await t.run(async (ctx) => {
+    await ctx.db.insert("messages", { author: "sarah", body: "hello" });
+  });
+  const { page } = await t.query(async (ctx) => paginateOnce(ctx));
+  expect(page).toMatchObject([{ author: "sarah", body: "hello" }]);
+});
+
+test("paginate in separate function executions does not throw", async () => {
+  const t = convexTest({ schema });
+  await t.run(async (ctx) => {
+    await ctx.db.insert("messages", { author: "sarah", body: "hello" });
+  });
+  // Each call is its own function execution, so the per-execution count resets.
+  const a = await t.query(async (ctx) => paginateOnce(ctx));
+  const b = await t.query(async (ctx) => paginateOnce(ctx));
+  expect(a.page.length).toBe(1);
+  expect(b.page.length).toBe(1);
+});
+
+test("paginate once per nested function via runQuery does not throw", async () => {
+  const t = convexTest({ schema });
+  await t.run(async (ctx) => {
+    await ctx.db.insert("messages", { author: "sarah", body: "hello" });
+  });
+  // An action invoking two queries, each paginating once. Each query is its
+  // own function execution, so this is allowed.
+  const result = await t.action(async (ctx) => {
+    const first = await ctx.runQuery(api.pagination.listAll, {
+      paginationOptions: { cursor: null, numItems: 10 },
+    });
+    const second = await ctx.runQuery(api.pagination.listAll, {
+      paginationOptions: { cursor: null, numItems: 10 },
+    });
+    return { first, second };
+  });
+  expect(result.first.page.length).toBe(1);
+  expect(result.second.page.length).toBe(1);
+});

--- a/index.ts
+++ b/index.ts
@@ -1381,6 +1381,22 @@ function asyncSyscallImpl() {
           maximumRowsRead,
           maximumBytesRead,
         } = args;
+        // Convex only allows a single paginated query (`.paginate()`) per
+        // function execution. Multiple `.paginate()` calls pass in the test
+        // mock but fail at runtime in a deployed function, so always enforce
+        // the rule.
+        const ctx = executionContextStorage.getStore();
+        if (ctx) {
+          ctx.paginatedQueries += 1;
+          if (ctx.paginatedQueries > 1) {
+            throw new Error(
+              "Only a single paginated query (`.paginate()`) is allowed per " +
+                "function execution. Calling `.paginate()` more than once in a " +
+                "single Convex function fails at runtime in a deployed backend. " +
+                "This is a Convex limit: https://docs.convex.dev/database/pagination",
+            );
+          }
+        }
         const { page, isDone, continueCursor, splitCursor, pageStatus } =
           db.paginate({
             query,
@@ -2038,6 +2054,9 @@ type ExecutionContext = {
   componentPath: string;
   udfPath: string;
   depth: number; // 0 = top-level, 1+ = nested
+  // Number of paginated queries (`.paginate()`) executed so far in this
+  // function execution. Convex only allows one per function invocation.
+  paginatedQueries: number;
 };
 
 const executionContextStorage = new AsyncLocalStorage<ExecutionContext>();
@@ -2236,6 +2255,10 @@ export function convexTest<Schema extends GenericSchema>(
  *     - `true` or `{}`: enforce default Convex limits
  *     - `{ bytesRead: 1024 }`: override specific limits
  *
+ * Regardless of `transactionLimits`, a single function execution may only run
+ * one paginated query (`.paginate()`); calling it more than once throws,
+ * matching the behavior of a deployed Convex backend.
+ *
  * @returns an object which is by convention stored in the `t` variable
  *   and which provides methods for exercising your Convex functions.
  *
@@ -2380,6 +2403,7 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
       componentPath: functionPath.componentPath,
       udfPath: functionPath.udfPath,
       depth: (parentCtx?.depth ?? 0) + 1,
+      paginatedQueries: 0,
     };
 
     await transactionManager.begin(isNested);
@@ -2430,6 +2454,7 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
       componentPath: functionPath.componentPath,
       udfPath: functionPath.udfPath,
       depth: (parentCtx?.depth ?? 0) + 1,
+      paginatedQueries: 0,
     };
 
     await transactionManager.begin(isNested);
@@ -2482,6 +2507,7 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
       componentPath: functionPath.componentPath,
       udfPath: functionPath.udfPath,
       depth: (parentCtx?.depth ?? 0) + 1,
+      paginatedQueries: 0,
     };
     return await executionContextStorage.run(childCtx, async () => {
       const requestId = "" + Math.random();
@@ -2788,6 +2814,7 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
         componentPath: getCurrentComponentPath(),
         udfPath: "http",
         depth: 0,
+        paginatedQueries: 0,
       };
       const response = await executionContextStorage.run(httpCtx, () =>
         (


### PR DESCRIPTION
Enforce the Convex runtime rule that only a single `.paginate()` call is allowed per function execution. Previously, calling `.paginate()` more than once in a single function would pass silently in tests but fail at runtime in a deployed backend. Now the test environment matches production behavior by throwing an error when `.paginate()` is called more than once within the same function execution.

A `paginatedQueries` counter is tracked on the `ExecutionContext` and incremented each time a paginated query runs. If the count exceeds one, an error is thrown with a message linking to the Convex pagination docs. The counter resets for each new function execution, so separate invocations (including nested queries called via `runQuery` from an action) are unaffected.

Fixes #121