### PR TITLE
remove raw snapshot query syscall

### DIFF
--- a/convex/mutations.ts
+++ b/convex/mutations.ts
@@ -1,10 +1,4 @@
-import { convexToJson, jsonToConvex, v } from "convex/values";
-import {
-  FunctionReference,
-  FunctionReturnType,
-  getFunctionAddress,
-  OptionalRestArgs,
-} from "convex/server";
+import { v } from "convex/values";
 import { mutation, query, internalQuery } from "./_generated/server";
 import { api, internal } from "./_generated/api";
 
@@ -164,29 +158,11 @@ export const snapshotQueryDoesNotSeePendingWrites = mutation({
       internal.mutations.countMessages,
     );
     // Snapshot query does NOT see the pending write
-    const withoutWrites = await runSnapshotQuery(
+    const withoutWrites: number = await ctx.runQuery(
       internal.mutations.countMessages,
+      {},
+      { useStaleSnapshot: true },
     );
     return { withWrites, withoutWrites };
   },
 });
-
-// Snapshot Query isn't part of the public `convex` API surface yet,
-// so call the underlying syscall directly.
-async function runSnapshotQuery<
-  Query extends FunctionReference<"query", "public" | "internal">,
->(
-  query: Query,
-  ...args: OptionalRestArgs<Query>
-): Promise<FunctionReturnType<Query>> {
-  const syscallArgs = {
-    udfType: "snapshotQuery",
-    args: convexToJson(args[0] ?? {}),
-    ...getFunctionAddress(query),
-  };
-  const resultStr = await (globalThis as any).Convex.asyncSyscall(
-    "1.0/runUdf",
-    JSON.stringify(syscallArgs),
-  );
-  return jsonToConvex(JSON.parse(resultStr)) as FunctionReturnType<Query>;
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@typescript-eslint/eslint-plugin": "8.58.2",
         "@typescript-eslint/parser": "8.58.2",
         "@vitest/coverage-v8": "1.6.1",
-        "convex": "1.41.0",
+        "convex": "^1.42.0",
         "eslint": "9.39.4",
         "globals": "17.5.0",
         "pkg-pr-new": "0.0.66",
@@ -2210,15 +2210,15 @@
       "license": "MIT"
     },
     "node_modules/convex": {
-      "version": "1.41.0",
-      "resolved": "https://registry.npmjs.org/convex/-/convex-1.41.0.tgz",
-      "integrity": "sha512-euxVf6yfpB7/VGKOobkLgjpbJidsUgW+b0ezonEyCUPqlpHFwR4/yIiI1hjjErzraiw91GxrtxpXQClMLNqU+w==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/convex/-/convex-1.42.0.tgz",
+      "integrity": "sha512-KS1U+YkE7N7jDfucPW28iNehnb9/N5n9RJmdAFNdPIHTeNpbLKNqk1pJHp4ajHyMBAhGmri8Z4S1lc1LjliZWQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "esbuild": "0.27.0",
         "prettier": "^3.0.0",
-        "ws": "8.20.1"
+        "ws": "8.21.0"
       },
       "bin": {
         "convex": "bin/main.js"
@@ -4817,9 +4817,9 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6247,14 +6247,14 @@
       "dev": true
     },
     "convex": {
-      "version": "1.41.0",
-      "resolved": "https://registry.npmjs.org/convex/-/convex-1.41.0.tgz",
-      "integrity": "sha512-euxVf6yfpB7/VGKOobkLgjpbJidsUgW+b0ezonEyCUPqlpHFwR4/yIiI1hjjErzraiw91GxrtxpXQClMLNqU+w==",
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/convex/-/convex-1.42.0.tgz",
+      "integrity": "sha512-KS1U+YkE7N7jDfucPW28iNehnb9/N5n9RJmdAFNdPIHTeNpbLKNqk1pJHp4ajHyMBAhGmri8Z4S1lc1LjliZWQ==",
       "dev": true,
       "requires": {
         "esbuild": "0.27.0",
         "prettier": "^3.0.0",
-        "ws": "8.20.1"
+        "ws": "8.21.0"
       }
     },
     "cross-spawn": {
@@ -7861,9 +7861,9 @@
       "dev": true
     },
     "ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "requires": {}
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@typescript-eslint/eslint-plugin": "8.58.2",
         "@typescript-eslint/parser": "8.58.2",
         "@vitest/coverage-v8": "1.6.1",
-        "convex": "^1.42.0",
+        "convex": "1.42.0",
         "eslint": "9.39.4",
         "globals": "17.5.0",
         "pkg-pr-new": "0.0.66",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@typescript-eslint/eslint-plugin": "8.58.2",
     "@typescript-eslint/parser": "8.58.2",
     "@vitest/coverage-v8": "1.6.1",
-    "convex": "1.41.0",
+    "convex": "^1.42.0",
     "eslint": "9.39.4",
     "globals": "17.5.0",
     "pkg-pr-new": "0.0.66",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@typescript-eslint/eslint-plugin": "8.58.2",
     "@typescript-eslint/parser": "8.58.2",
     "@vitest/coverage-v8": "1.6.1",
-    "convex": "^1.42.0",
+    "convex": "1.42.0",
     "eslint": "9.39.4",
     "globals": "17.5.0",
     "pkg-pr-new": "0.0.66",


### PR DESCRIPTION
remove the raw snapshot query syscall and use the new `{ useStaleSnapshot: true }` option in `ctx.runQuery` instead