### PR TITLE
Support db.vars.commitTs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Support `db.vars.commitTs` and `v.commitTs()`.
+
 ## 0.0.54
 
 - Support the `transactionLimits` option on nested `ctx.runQuery` /

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -12,6 +12,7 @@ import type * as actions from "../actions.js";
 import type * as argumentsValidation from "../argumentsValidation.js";
 import type * as auditLogging from "../auditLogging.js";
 import type * as authentication from "../authentication.js";
+import type * as commitTs from "../commitTs.js";
 import type * as component from "../component.js";
 import type * as convexError from "../convexError.js";
 import type * as explicitTableNames from "../explicitTableNames.js";
@@ -41,6 +42,7 @@ declare const fullApi: ApiFromModules<{
   argumentsValidation: typeof argumentsValidation;
   auditLogging: typeof auditLogging;
   authentication: typeof authentication;
+  commitTs: typeof commitTs;
   component: typeof component;
   convexError: typeof convexError;
   explicitTableNames: typeof explicitTableNames;

--- a/convex/commitTs.test.ts
+++ b/convex/commitTs.test.ts
@@ -1,0 +1,221 @@
+/// <reference types="vite/client" />
+
+import { expect, test } from "vitest";
+import { defineSchema, defineTable } from "convex/server";
+import { convexToJson, v } from "convex/values";
+import { convexTest } from "../index";
+import { api, components, internal } from "./_generated/api";
+import schema from "./schema";
+import counterSchema from "./counter/component/schema";
+
+const counterModules = import.meta.glob("./counter/component/**/*.ts");
+
+function expectBigint(value: unknown): bigint {
+  if (typeof value !== "bigint") {
+    expect.fail(`expected a bigint, got ${typeof value}`);
+  }
+  return value;
+}
+
+test("insert reads back unresolved, commits as an increasing int64", async () => {
+  const t = convexTest(schema);
+  const first = await t.mutation(api.commitTs.insertAndReadBack, {});
+  const second = await t.mutation(api.commitTs.insertAndReadBack, {});
+
+  const timestamps: bigint[] = [];
+  for (const id of [first, second]) {
+    const doc = await t.query(api.commitTs.getCommitTs, { id });
+    // All positions in one transaction share its commit timestamp.
+    expect(doc.commitTs).toBe(doc.nestedCommitTs);
+    timestamps.push(expectBigint(doc.commitTs));
+  }
+  // Commit timestamps increase across transactions, so the index over
+  // `commitTs` is ordered by commit order.
+  expect(timestamps[0]).toBeLessThan(timestamps[1]);
+  expect(await t.query(api.commitTs.commitTsInIndexOrder, {})).toEqual(
+    timestamps,
+  );
+});
+
+test("placeholder round-trips through a nested mutation's args and return", async () => {
+  const t = convexTest(schema);
+  await t.mutation(api.commitTs.callNestedWithCommitTsArg, {});
+  const timestamps = await t.query(api.commitTs.commitTsInIndexOrder, {});
+  expect(timestamps).toHaveLength(2);
+  // The nested mutation and the parent share one commit timestamp.
+  expect(timestamps[0]).toBe(timestamps[1]);
+  expectBigint(timestamps[0]);
+});
+
+test("nested query reads the parent's pending write", async () => {
+  const t = convexTest(schema);
+  const id = await t.mutation(api.commitTs.nestedQueryReadsPending, {});
+  const doc = await t.query(api.commitTs.getDoc, { id });
+  expectBigint(doc!.commitTs);
+});
+
+test("a top-level mutation's return value is resolved", async () => {
+  const t = convexTest(schema);
+  const returned = await t.mutation(api.commitTs.returnCommitTs, {});
+  expectBigint(returned.ts);
+  expect(returned.nested[0]).toBe(returned.ts);
+  const doc = await t.query(api.commitTs.getDoc, { id: returned.id });
+  // The caller sees the value the document was committed with.
+  expect(doc!.commitTs).toBe(returned.ts);
+});
+
+test("index ranges over pending rows", async () => {
+  const t = convexTest(schema);
+  // The mutation asserts eq(db.vars.commitTs) matches exactly its staged rows
+  // and returns how many committed rows lt(db.vars.commitTs) saw: none on the
+  // first run, the first run's two resolved rows on the second.
+  expect(await t.mutation(api.commitTs.indexRangeOverPending, {})).toBe(0);
+  expect(await t.mutation(api.commitTs.indexRangeOverPending, {})).toBe(2);
+
+  // In a query, nothing is staged, so a placeholder's range matches no rows
+  // even though the table has committed rows.
+  expect(await t.query(api.commitTs.indexRangeEqPlaceholderInQuery, {})).toBe(
+    0,
+  );
+});
+
+test("scheduling with a placeholder argument is rejected", async () => {
+  const t = convexTest(schema);
+  await expect(
+    t.mutation(api.commitTs.scheduleWithCommitTs, {}),
+  ).rejects.toThrow("Invalid arguments");
+});
+
+test("a query cannot return a placeholder", async () => {
+  const t = convexTest(schema);
+  await expect(
+    t.query(api.commitTs.queryReturnsPlaceholder, {}),
+  ).rejects.toThrow("return value invalid");
+});
+
+test("patch", async () => {
+  const t = convexTest(schema);
+  const id = await t.mutation(api.commitTs.patchPendingAndReadBack, {});
+  const doc = await t.query(api.commitTs.getDoc, { id });
+  const firstCommitTs = expectBigint(doc!.commitTs);
+  expect(doc!.other).toBe("world");
+
+  // Patching an unresolved commit timestamp into a committed document gives the
+  // new field the patching transaction's commit timestamp while untouched
+  // fields keep their values.
+  await t.mutation(api.commitTs.patchCommitTsIntoCommittedDocument, { id });
+  const patched = await t.query(api.commitTs.getDoc, { id });
+  expect(patched!.commitTs).toBe(firstCommitTs);
+  expect(expectBigint(patched!.patchedCommitTs)).toBeGreaterThan(firstCommitTs);
+});
+
+test("replace", async () => {
+  const t = convexTest(schema);
+  const id = await t.mutation(api.commitTs.replacePendingAndReadBack, {});
+  const doc = await t.query(api.commitTs.getDoc, { id });
+  expectBigint(doc!.replacedCommitTs);
+  expect(doc!.commitTs).toBeUndefined();
+});
+
+test("t.run is a top-level transaction, so its placeholders resolve", async () => {
+  const t = convexTest(schema);
+  const ts = expectBigint(await t.run(async (ctx) => ctx.db.vars.commitTs));
+
+  const id = await t.run(async (ctx) =>
+    ctx.db.insert("commitTs", { commitTs: ctx.db.vars.commitTs }),
+  );
+  // A later transaction reads the committed value.
+  const committed = expectBigint(
+    await t.run(async (ctx) => (await ctx.db.get(id))!.commitTs),
+  );
+  expect(committed).toBeGreaterThan(ts);
+});
+
+test("paginating over rows staged in the writing mutation", async () => {
+  const t = convexTest(schema);
+  const result = await t.mutation(api.commitTs.paginateOverPending, {});
+  expect(result.pageSize).toBe(2);
+  expect(result.isDone).toBe(false);
+  // The cursor's leading key is the indexed `commitTs` field, encoded from the
+  // pre-commit view rather than from the placeholder.
+  const [commitTsKey] = JSON.parse(result.continueCursor) as string[];
+  expect(JSON.parse(commitTsKey)).toEqual(convexToJson(2n ** 63n - 1n));
+});
+
+test("filtering on a field staged in the writing mutation", async () => {
+  const t = convexTest(schema);
+  await t.mutation(api.commitTs.insertAndReadBack, {});
+  // Both the committed row and the staged one are greater than zero; the staged
+  // one only compares at all because `.filter()` sees the pre-commit view.
+  expect(await t.mutation(api.commitTs.filterOverPending, {})).toBe(2);
+});
+
+test("staged rows sort after committed ones", async () => {
+  const t = convexTest(schema);
+  await t.mutation(api.commitTs.insertAndReadBack, {});
+  expect(await t.mutation(api.commitTs.stagedRowsSortLast, {})).toEqual({
+    total: 2,
+    stagedIsLast: true,
+  });
+});
+
+test("a rolled back mutation writes nothing and still advances the last commit timestamp", async () => {
+  const t = convexTest(schema);
+  const before = await t.mutation(api.commitTs.returnCommitTs, {});
+  await expect(t.mutation(api.commitTs.insertThenThrow, {})).rejects.toThrow(
+    "rollback",
+  );
+  // Only the successful mutation's row is present.
+  expect(await t.query(api.commitTs.commitTsInIndexOrder, {})).toEqual([
+    before.ts,
+  ]);
+  const after = await t.mutation(api.commitTs.returnCommitTs, {});
+  expect(expectBigint(after.ts)).toBeGreaterThan(expectBigint(before.ts));
+});
+
+test("the app and a component share one commit timestamp", async () => {
+  const t = convexTest(schema);
+  t.registerComponent("counter", counterSchema, counterModules);
+  const id = await t.mutation(internal.component.writeCommitTsAcrossComponents);
+  const appCommitTs = expectBigint(
+    (await t.query(api.commitTs.getDoc, { id }))!.commitTs,
+  );
+  const componentCommitTs = await t.query(
+    components.counter.public.getCommitTs,
+    { name: "commitTs" },
+  );
+  expect(componentCommitTs).toBe(appCommitTs);
+});
+
+test("validators treat a placeholder as the int64 it will become", async () => {
+  const int64Schema = defineSchema({
+    values: defineTable({ ts: v.int64() }),
+  });
+  const t = convexTest(int64Schema);
+  // `v.int64()` accepts a placeholder at runtime, because the backend validates
+  // the pre-commit view, but it types the field as `bigint`, hence the cast.
+  const id = await t.run(async (ctx) =>
+    ctx.db.insert("values", { ts: ctx.db.vars.commitTs as any }),
+  );
+  expectBigint(await t.run(async (ctx) => (await ctx.db.get(id))!.ts));
+
+  const stringSchema = defineSchema({
+    values: defineTable({ ts: v.string() }),
+  });
+  const t2 = convexTest(stringSchema);
+  await expect(
+    t2.run(async (ctx) =>
+      ctx.db.insert("values", { ts: ctx.db.vars.commitTs as any }),
+    ),
+  ).rejects.toThrow("Validator error");
+});
+
+test("v.commitTs() accepts a resolved timestamp", async () => {
+  const t = convexTest(schema);
+  const id = await t.mutation(api.commitTs.patchPendingAndReadBack, {});
+  // The patch re-validates the whole document, whose `commitTs` is a plain
+  // bigint by now.
+  await t.mutation(api.commitTs.patchCommitTsIntoCommittedDocument, { id });
+  const doc = await t.query(api.commitTs.getDoc, { id });
+  expectBigint(doc!.commitTs);
+});

--- a/convex/commitTs.ts
+++ b/convex/commitTs.ts
@@ -1,0 +1,291 @@
+import { api } from "./_generated/api";
+import { mutation, query } from "./_generated/server";
+import { CommitTsPlaceholder, v } from "convex/values";
+
+function assert(condition: boolean, message: string) {
+  if (!condition) {
+    throw new Error(`Assertion failed: ${message}`);
+  }
+}
+
+function assertThrows(f: () => unknown, message: string) {
+  try {
+    f();
+  } catch {
+    return;
+  }
+  throw new Error(`Expected an error: ${message}`);
+}
+
+export const insertAndReadBack = mutation(async ({ db }) => {
+  const id = await db.insert("commitTs", {
+    commitTs: db.vars.commitTs,
+    nested: { commitTs: db.vars.commitTs },
+  });
+
+  // Within the writing mutation, every read of the new document yields the
+  // unresolved placeholder.
+  const viaGet = (await db.get(id))!;
+  assert(viaGet.commitTs === db.vars.commitTs, "db.get commitTs");
+  assert(
+    viaGet.nested!.commitTs === db.vars.commitTs,
+    "db.get nested commitTs",
+  );
+
+  const viaQuery = (
+    await db.query("commitTs").withIndex("by_commit_ts").collect()
+  ).find((d) => d._id === id)!;
+  assert(viaQuery.commitTs === db.vars.commitTs, "indexed query commitTs");
+
+  const viaPaginate = (
+    await db.query("commitTs").paginate({ cursor: null, numItems: 10 })
+  ).page.find((d) => d._id === id)!;
+  assert(viaPaginate.commitTs === db.vars.commitTs, "paginated query commitTs");
+
+  // The placeholder cannot be used as a value.
+  assertThrows(() => Number(viaGet.commitTs), "Number() coercion");
+  assertThrows(() => (viaGet.commitTs as any) + 1, "arithmetic coercion");
+  assertThrows(() => JSON.stringify(viaGet), "JSON.stringify");
+
+  return id;
+});
+
+export const patchPendingAndReadBack = mutation(async ({ db }) => {
+  const id = await db.insert("commitTs", {
+    commitTs: db.vars.commitTs,
+    other: "hello",
+  });
+
+  // A patch that doesn't touch the unresolved commit timestamp leaves it
+  // unresolved.
+  await db.patch(id, { other: "world" });
+  const patched = (await db.get(id))!;
+  assert(patched.commitTs === db.vars.commitTs, "patch preserves commitTs");
+  assert(patched.other === "world", "patch applies other fields");
+
+  return id;
+});
+
+export const patchCommitTsIntoCommittedDocument = mutation({
+  args: { id: v.id("commitTs") },
+  handler: async ({ db }, { id }) => {
+    await db.patch(id, { patchedCommitTs: db.vars.commitTs });
+    const patched = (await db.get(id))!;
+    assert(
+      patched.patchedCommitTs === db.vars.commitTs,
+      "patched commitTs reads back unresolved",
+    );
+  },
+});
+
+export const replacePendingAndReadBack = mutation(async ({ db }) => {
+  const id = await db.insert("commitTs", {
+    commitTs: db.vars.commitTs,
+  });
+
+  await db.replace(id, { replacedCommitTs: db.vars.commitTs });
+  const replaced = (await db.get(id))!;
+  assert(
+    replaced.replacedCommitTs === db.vars.commitTs,
+    "replaced commitTs reads back unresolved",
+  );
+  assert(replaced.commitTs === undefined, "replace discards the old body");
+
+  return id;
+});
+
+export const getCommitTs = query({
+  args: { id: v.id("commitTs") },
+  handler: async ({ db }, { id }) => {
+    const doc = (await db.get(id))!;
+    return { commitTs: doc.commitTs, nestedCommitTs: doc.nested!.commitTs };
+  },
+});
+
+export const getDoc = query({
+  args: { id: v.id("commitTs") },
+  handler: async ({ db }, { id }) => db.get(id),
+});
+
+export const commitTsInIndexOrder = query(async ({ db }) => {
+  const docs = await db.query("commitTs").withIndex("by_commit_ts").collect();
+  return docs.map((d) => d.commitTs);
+});
+
+// Nested-call target: takes an unresolved commit timestamp as a validated
+// argument, inserts it, and returns it.
+export const insertCommitTsArg = mutation({
+  args: { ts: v.commitTs() },
+  returns: v.commitTs(),
+  handler: async ({ db }, { ts }) => {
+    await db.insert("commitTs", { commitTs: ts });
+    return ts;
+  },
+});
+
+export const callNestedWithCommitTsArg = mutation(async (ctx) => {
+  const returned = await ctx.runMutation(api.commitTs.insertCommitTsArg, {
+    ts: ctx.db.vars.commitTs,
+  });
+  // The placeholder round-trips through the nested call's arguments and
+  // return value as the same singleton.
+  assert(
+    returned === ctx.db.vars.commitTs,
+    "nested return value is the placeholder",
+  );
+  // Insert from the parent too: the whole transaction, including the nested
+  // mutation, shares one commit timestamp.
+  await ctx.db.insert("commitTs", { commitTs: ctx.db.vars.commitTs });
+});
+
+export const nestedQueryReadsPending = mutation(async (ctx) => {
+  const id = await ctx.db.insert("commitTs", {
+    commitTs: ctx.db.vars.commitTs,
+  });
+  // A nested query shares the transaction, so it reads the pending document
+  // and returns the unresolved placeholder.
+  const doc = await ctx.runQuery(api.commitTs.getDoc, { id });
+  assert(
+    doc!.commitTs === ctx.db.vars.commitTs,
+    "nested query returns the placeholder",
+  );
+  return id;
+});
+
+// The returned placeholders resolve to the transaction's commit timestamp
+// after commit, so the caller sees the same value the document was committed
+// with.
+export const returnCommitTs = mutation({
+  returns: v.object({
+    id: v.id("commitTs"),
+    ts: v.commitTs(),
+    nested: v.array(v.commitTs()),
+  }),
+  handler: async ({ db }) => {
+    const id = await db.insert("commitTs", { commitTs: db.vars.commitTs });
+    return { id, ts: db.vars.commitTs, nested: [db.vars.commitTs] };
+  },
+});
+
+// Index range values are interpreted in the transaction's pre-commit view,
+// where unresolved commit timestamps sort as the maximum int64: eq on
+// `db.vars.commitTs` matches exactly this transaction's staged rows, and lt
+// matches only committed rows. Returns the committed-row count.
+export const indexRangeOverPending = mutation(async ({ db, runQuery }) => {
+  const eqPending = () =>
+    db
+      .query("commitTs")
+      .withIndex("by_commit_ts", (q) => q.eq("commitTs", db.vars.commitTs))
+      .collect();
+
+  assert((await eqPending()).length === 0, "eq matches nothing before staging");
+
+  const first = await db.insert("commitTs", { commitTs: db.vars.commitTs });
+  const second = await db.insert("commitTs", { commitTs: db.vars.commitTs });
+
+  const staged = await eqPending();
+  assert(
+    staged.length === 2 &&
+      staged.some((d) => d._id === first) &&
+      staged.some((d) => d._id === second),
+    "eq matches exactly the staged rows",
+  );
+  assert(
+    staged.every((d) => d.commitTs === db.vars.commitTs),
+    "staged rows read back unresolved",
+  );
+
+  // Also observable from a nested query
+  const nestedStaged = await runQuery(
+    api.commitTs.indexRangeEqPlaceholderInQuery,
+    {},
+  );
+  assert(nestedStaged === 2, "nested query sees the same staged rows");
+
+  const committed = await db
+    .query("commitTs")
+    .withIndex("by_commit_ts", (q) => q.lt("commitTs", db.vars.commitTs))
+    .collect();
+  assert(
+    committed.every((d) => typeof d.commitTs === "bigint"),
+    "lt matches only committed rows",
+  );
+  return committed.length;
+});
+
+// The pre-commit-view interpretation is uniform across function types: a
+// query stages no writes, so a placeholder's range matches no rows.
+export const indexRangeEqPlaceholderInQuery = query(async ({ db }) => {
+  const rows = await db
+    .query("commitTs")
+    .withIndex("by_commit_ts", (q) =>
+      q.eq("commitTs", new CommitTsPlaceholder()),
+    )
+    .collect();
+  return rows.length;
+});
+
+// Scheduled-job arguments still reject the placeholder: they are persisted,
+// not resolved within this transaction.
+export const scheduleWithCommitTs = mutation(async (ctx) => {
+  await ctx.scheduler.runAfter(0, api.commitTs.insertCommitTsArg, {
+    ts: ctx.db.vars.commitTs,
+  });
+});
+
+// Queries have no commit timestamp; a fabricated placeholder is rejected when
+// the query returns.
+export const queryReturnsPlaceholder = query(() => {
+  return new CommitTsPlaceholder() as any;
+});
+
+// A mutation that stages an unresolved commit timestamp and then fails, so the
+// write is rolled back.
+export const insertThenThrow = mutation(async ({ db }) => {
+  await db.insert("commitTs", { commitTs: db.vars.commitTs });
+  throw new Error("rollback");
+});
+
+// Paginating over rows this mutation staged. The continuation cursor is encoded
+// from the last row's pre-commit view, which would throw if it were encoded from
+// the placeholder itself. Only one `.paginate()` is allowed per function, so the
+// cursor is returned rather than followed here.
+export const paginateOverPending = mutation(async ({ db }) => {
+  await db.insert("commitTs", { commitTs: db.vars.commitTs, other: "a" });
+  await db.insert("commitTs", { commitTs: db.vars.commitTs, other: "b" });
+  await db.insert("commitTs", { commitTs: db.vars.commitTs, other: "c" });
+
+  const page = await db
+    .query("commitTs")
+    .withIndex("by_commit_ts")
+    .paginate({ cursor: null, numItems: 2 });
+  return {
+    pageSize: page.page.length,
+    isDone: page.isDone,
+    continueCursor: page.continueCursor,
+  };
+});
+
+// Committed rows sort before rows this mutation staged, because an unresolved
+// commit timestamp sorts as the maximum int64 in the pre-commit view.
+export const stagedRowsSortLast = mutation(async ({ db }) => {
+  const staged = await db.insert("commitTs", { commitTs: db.vars.commitTs });
+  const docs = await db.query("commitTs").withIndex("by_commit_ts").collect();
+  return {
+    total: docs.length,
+    stagedIsLast: docs[docs.length - 1]._id === staged,
+  };
+});
+
+// `.filter()` compiles to expressions evaluated with raw JS operators, which
+// would throw on the placeholder; they see the pre-commit view instead. The
+// staged row's timestamp is the maximum int64, so it passes `gt` against any
+// committed one.
+export const filterOverPending = mutation(async ({ db }) => {
+  await db.insert("commitTs", { commitTs: db.vars.commitTs });
+  const matched = await db
+    .query("commitTs")
+    .filter((q) => q.gt(q.field("commitTs"), 0n))
+    .collect();
+  return matched.length;
+});

--- a/convex/component.ts
+++ b/convex/component.ts
@@ -253,3 +253,18 @@ export const parallelSequentialComponentQueries = internalQuery({
     return { count1a, count1b, count2a, count2b };
   },
 });
+
+// Writes in both the app and the component within one transaction, so both rows
+// must land on the same commit timestamp.
+export const writeCommitTsAcrossComponents = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const id = await ctx.db.insert("commitTs", {
+      commitTs: ctx.db.vars.commitTs,
+    });
+    await ctx.runMutation(components.counter.public.addWithCommitTs, {
+      name: "commitTs",
+    });
+    return id;
+  },
+});

--- a/convex/counter/component/_generated/component.ts
+++ b/convex/counter/component/_generated/component.ts
@@ -31,6 +31,13 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         null,
         Name
       >;
+      addWithCommitTs: FunctionReference<
+        "mutation",
+        "internal",
+        { name: string },
+        any,
+        Name
+      >;
       count: FunctionReference<
         "query",
         "internal",
@@ -50,6 +57,13 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         "internal",
         { names: Array<string> },
         Array<number>,
+        Name
+      >;
+      getCommitTs: FunctionReference<
+        "query",
+        "internal",
+        { name: string },
+        any,
         Name
       >;
       getIdentityName: FunctionReference<"query", "internal", {}, any, Name>;

--- a/convex/counter/component/public.ts
+++ b/convex/counter/component/public.ts
@@ -115,3 +115,28 @@ export const metadata = query({
     return await ctx.meta.getFunctionMetadata();
   },
 });
+
+// Writes a row carrying the transaction's commit timestamp, so a caller can
+// check that the app and the component share one timestamp.
+export const addWithCommitTs = mutation({
+  args: { name: v.string() },
+  handler: async (ctx, args) => {
+    return await ctx.db.insert("counters", {
+      name: args.name,
+      value: 0,
+      shard: 0,
+      commitTs: ctx.db.vars.commitTs,
+    });
+  },
+});
+
+export const getCommitTs = query({
+  args: { name: v.string() },
+  handler: async (ctx, args) => {
+    const doc = await ctx.db
+      .query("counters")
+      .withIndex("name", (q) => q.eq("name", args.name).eq("shard", 0))
+      .unique();
+    return doc!.commitTs ?? null;
+  },
+});

--- a/convex/counter/component/schema.ts
+++ b/convex/counter/component/schema.ts
@@ -6,5 +6,6 @@ export default defineSchema({
     name: v.string(),
     value: v.number(),
     shard: v.number(),
+    commitTs: v.optional(v.commitTs()),
   }).index("name", ["name", "shard"]),
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2,6 +2,13 @@ import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
 
 export default defineSchema({
+  commitTs: defineTable({
+    commitTs: v.optional(v.commitTs()),
+    patchedCommitTs: v.optional(v.commitTs()),
+    replacedCommitTs: v.optional(v.commitTs()),
+    nested: v.optional(v.object({ commitTs: v.commitTs() })),
+    other: v.optional(v.string()),
+  }).index("by_commit_ts", ["commitTs"]),
   messages: defineTable({
     author: v.string(),
     body: v.string(),

--- a/index.ts
+++ b/index.ts
@@ -30,6 +30,7 @@ import {
   queryGeneric,
 } from "convex/server";
 import {
+  CommitTsPlaceholder,
   GenericId,
   JSONValue,
   Value,
@@ -396,7 +397,7 @@ class DatabaseFake {
     }
   }
 
-  commit() {
+  commit(commitTs: bigint | null = null) {
     const lastWrites = this._writes.pop();
     if (!lastWrites) {
       throw new Error("Transaction already committed or rolled back");
@@ -407,7 +408,8 @@ class DatabaseFake {
         if (write === null) {
           delete this._documents[_id];
         } else {
-          this._documents[_id] = write;
+          this._documents[_id] =
+            commitTs === null ? write : resolveCommittedValues(write, commitTs);
         }
       } else {
         this._addWrite(_id, write);
@@ -441,7 +443,9 @@ class DatabaseFake {
     if (validator === undefined) {
       return;
     }
-    validateValidator(validator, doc);
+    // Validate the pre-commit view, like the backend does, so an unresolved
+    // commit timestamp is checked as the int64 it will become.
+    validateValidator(validator, resolvePendingValues(doc));
   }
 
   startQuery(query: SerializedQuery) {
@@ -888,6 +892,53 @@ function isSimpleObject(value: unknown) {
   return isObject && isSimple;
 }
 
+// Commit timestamp placeholders are resolved to `i64::MAX` before commit.
+const MAX_COMMIT_TS = 2n ** 63n - 1n;
+
+function hasPendingValues(value: Value): boolean {
+  if (value instanceof CommitTsPlaceholder) {
+    return true;
+  }
+  if (Array.isArray(value)) {
+    return value.some(hasPendingValues);
+  }
+  if (value !== null && value !== undefined && isSimpleObject(value)) {
+    return Object.values(value).some(hasPendingValues);
+  }
+  return false;
+}
+
+// The value as the transaction sees it before committing.
+function resolvePendingValues(value: Value): Value {
+  return substituteCommitTs(value, MAX_COMMIT_TS);
+}
+
+// The value as it is committed.
+function resolveCommittedValues<T extends Value>(
+  value: T,
+  commitTs: bigint,
+): T {
+  return substituteCommitTs(value, commitTs);
+}
+
+function substituteCommitTs<T extends Value>(value: T, commitTs: bigint): T {
+  if (!hasPendingValues(value)) {
+    return value;
+  }
+  if (value instanceof CommitTsPlaceholder) {
+    return commitTs as T;
+  }
+  if (Array.isArray(value)) {
+    return value.map((v) => substituteCommitTs(v, commitTs)) as T;
+  }
+  return Object.fromEntries(
+    Object.entries(value as object).map(([k, v]) => [
+      k,
+      substituteCommitTs(v, commitTs),
+    ]),
+  ) as T;
+}
+
 function evaluateFieldPath(fieldPath: string, document: any) {
   const pathParts = fieldPath.split(".");
   let result: Value | undefined = document;
@@ -897,7 +948,7 @@ function evaluateFieldPath(fieldPath: string, document: any) {
         ? (result as any)[p]
         : undefined;
   }
-  return result;
+  return result === undefined ? undefined : resolvePendingValues(result);
 }
 
 function evaluateFilter(
@@ -987,7 +1038,7 @@ function evaluateFilter(
     return evaluateFieldPath(filter.$field, document);
   }
   if (filter.$literal !== undefined) {
-    return evaluateValue(filter.$literal);
+    return evaluateQueryValue(filter.$literal);
   }
   throw new Error(`not implemented: ${JSON.stringify(filter)}`);
 }
@@ -997,7 +1048,7 @@ function evaluateRangeFilter(
   expr: SerializedRangeExpression,
 ) {
   const result = evaluateFieldPath(expr.fieldPath, document);
-  const value = evaluateValue(expr.value);
+  const value = evaluateQueryValue(expr.value);
   switch (expr.type) {
     case "Eq":
       return compareValues(result, value) === 0;
@@ -1012,11 +1063,20 @@ function evaluateRangeFilter(
   }
 }
 
+// A value used as a written field.
 function evaluateValue(value: JSONValue) {
   if (typeof value === "object" && value !== null && "$undefined" in value) {
     return undefined;
   }
   return jsonToConvex(value);
+}
+
+// A value used as a query bound or literal.
+function evaluateQueryValue(value: JSONValue) {
+  const evaluatedValue = evaluateValue(value);
+  return evaluatedValue === undefined
+    ? undefined
+    : resolvePendingValues(evaluatedValue);
 }
 
 function evaluateSearchFilter(
@@ -1026,7 +1086,7 @@ function evaluateSearchFilter(
   const result = evaluateFieldPath(filter.fieldPath, document);
   switch (filter.type) {
     case "Eq":
-      return compareValues(result, evaluateValue(filter.value)) === 0;
+      return compareValues(result, evaluateQueryValue(filter.value)) === 0;
     case "Search": {
       const queryTerms = filter.value
         .toLowerCase()
@@ -1157,6 +1217,7 @@ type ValidatorJSON =
     }
   | { type: "number" }
   | { type: "bigint" }
+  | { type: "commitTs" }
   | { type: "boolean" }
   | { type: "string" }
   | { type: "bytes" }
@@ -1190,6 +1251,17 @@ function validateValidator(validator: ValidatorJSON, value: any) {
       if (typeof value !== "bigint") {
         throw new Error(
           `Validator error: Expected \`bigint\`, got \`${value}\``,
+        );
+      }
+      return;
+    }
+    case "commitTs": {
+      if (
+        typeof value !== "bigint" &&
+        !(value instanceof CommitTsPlaceholder)
+      ) {
+        throw new Error(
+          `Validator error: Expected \`v.commitTs()\`, got \`${value}\``,
         );
       }
       return;
@@ -1587,6 +1659,13 @@ function asyncSyscallImpl() {
         const functionPath = getFunctionPathFromAddress(functionAddress);
         // Convert args to a Convex value before storing them or passing them to the function
         const parsedArgs = jsonToConvex(fnArgs);
+        // Scheduled arguments cannot contain pending values
+        if (hasPendingValues(parsedArgs)) {
+          throw new Error(
+            `Invalid arguments for "${functionPath.udfPath}": a scheduled ` +
+              `function cannot take an unresolved placeholder value.`,
+          );
+        }
 
         tracker?.trackScheduledFunction(getConvexSize(parsedArgs));
 
@@ -2156,6 +2235,8 @@ class TransactionManager {
   // `startTransaction` / `commit` / `rollback` in lockstep with the databases'.
   private _metricsTracker: TransactionMetricsTracker | null = null;
   private _limitsConfig: Partial<TransactionMetrics> | boolean;
+  // The last commit timestamp handed out. Strictly increases across transactions.
+  private _lastCommitTs: bigint = 0n;
 
   constructor(limitsConfig: Partial<TransactionMetrics> | boolean = false) {
     this._limitsConfig = limitsConfig;
@@ -2199,13 +2280,24 @@ class TransactionManager {
     return this._metricsTracker;
   }
 
-  commit(isNested: boolean) {
+  // Returns the transaction's commit timestamp, or null for a nested commit,
+  // whose writes stay pending until the outermost transaction commits.
+  commit(isNested: boolean): bigint | null {
+    let commitTs: bigint | null = null;
+    if (!isNested) {
+      const nowNanos = BigInt(Date.now()) * 1_000_000n;
+      // Bump by one if the clock has not advanced since the last commit.
+      commitTs =
+        nowNanos > this._lastCommitTs ? nowNanos : this._lastCommitTs + 1n;
+      this._lastCommitTs = commitTs;
+    }
     const convex = getConvexGlobal();
     for (const component of Object.values(convex.components)) {
-      component.db.commit();
+      component.db.commit(commitTs);
     }
     this._metricsTracker?.commit();
     this._endTransaction(isNested);
+    return commitTs;
   }
 
   rollback(isNested: boolean) {
@@ -2449,8 +2541,11 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
 
       const rawResult = await nestedTxStorage.run(childLock, invokeInContext);
 
-      transactionManager.commit(isNested);
-      return jsonToConvex(JSON.parse(rawResult)) as T;
+      const commitTs = transactionManager.commit(isNested);
+      const result = jsonToConvex(JSON.parse(rawResult));
+      return commitTs === null
+        ? (result as T)
+        : (resolveCommittedValues(result, commitTs) as T);
     } catch (e) {
       transactionManager.rollback(isNested);
       throw deserializeConvexErrorData(e);
@@ -2499,7 +2594,14 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
 
       const rawResult = await nestedTxStorage.run(childLock, invokeInContext);
 
-      return jsonToConvex(JSON.parse(rawResult)) as T;
+      const result = jsonToConvex(JSON.parse(rawResult));
+      if (!isNested && hasPendingValues(result)) {
+        throw new Error(
+          `Function ${functionPath.udfPath} return value invalid: queries ` +
+            `cannot return an unresolved placeholder value.`,
+        );
+      }
+      return result as T;
     } catch (e) {
       throw deserializeConvexErrorData(e);
     } finally {
@@ -2573,7 +2675,12 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
       }
       try {
         const resolved = await resolveFunction(functionPath, "query");
-        validateValidator(resolved.args, args ?? {});
+        validateFunctionArgs(
+          resolved.args,
+          args ?? {},
+          resolved.functionPath,
+          isNested,
+        );
 
         const result = await runQueryWithHandler(
           resolved.handler,
@@ -2610,7 +2717,13 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
       const stashed = transactionManager.stashWrites();
       try {
         const resolved = await resolveFunction(functionPath, "query");
-        validateValidator(resolved.args, args ?? {});
+        validateFunctionArgs(
+          resolved.args,
+          args ?? {},
+          resolved.functionPath,
+          // Only reachable from inside a mutation.
+          /* allowPendingValues */ true,
+        );
 
         const result = await runQueryWithHandler(
           resolved.handler,
@@ -2648,7 +2761,12 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
       }
       try {
         const resolved = await resolveFunction(functionPath, "mutation");
-        validateValidator(resolved.args, args ?? {});
+        validateFunctionArgs(
+          resolved.args,
+          args ?? {},
+          resolved.functionPath,
+          isNested,
+        );
 
         const result = await runMutationWithHandler(
           resolved.handler,
@@ -2674,7 +2792,13 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
 
     actionFromPath: async (functionPath: FunctionPath, args: any) => {
       const resolved = await resolveFunction(functionPath, "action");
-      validateValidator(resolved.args, args ?? {});
+      // An action runs outside any transaction.
+      validateFunctionArgs(
+        resolved.args,
+        args ?? {},
+        resolved.functionPath,
+        /* allowPendingValues */ false,
+      );
 
       const result = await runActionWithHandler(
         resolved.handler,
@@ -2935,6 +3059,22 @@ function parseArgs(
   return args;
 }
 
+function validateFunctionArgs(
+  argsValidator: ValidatorJSON,
+  args: any,
+  functionPath: FunctionPath,
+  allowPendingValues: boolean,
+) {
+  if (!allowPendingValues && hasPendingValues(args)) {
+    throw new Error(
+      `Invalid arguments for "${functionPath.udfPath}": an unresolved ` +
+        `placeholder value can only be passed to a query or mutation ` +
+        `called from a mutation`,
+    );
+  }
+  validateValidator(argsValidator, resolvePendingValues(args));
+}
+
 function validateReturnValue(
   returnsValidator: ValidatorJSON | null,
   result: any,
@@ -2943,7 +3083,7 @@ function validateReturnValue(
 ) {
   if (returnsValidator !== null) {
     try {
-      validateValidator(returnsValidator, result);
+      validateValidator(returnsValidator, resolvePendingValues(result));
     } catch (e) {
       throw new Error(
         `Return value validation failed for ${functionType} "${functionPath.udfPath}":\n${(e as Error).message}`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@typescript-eslint/eslint-plugin": "8.58.2",
         "@typescript-eslint/parser": "8.58.2",
         "@vitest/coverage-v8": "1.6.1",
-        "convex": "1.42.0",
+        "convex": "1.43.0",
         "eslint": "9.39.4",
         "globals": "17.5.0",
         "pkg-pr-new": "0.0.66",
@@ -26,7 +26,7 @@
         "vitest": "1.6.1"
       },
       "peerDependencies": {
-        "convex": "^1.32.0"
+        "convex": "^1.43.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2210,9 +2210,9 @@
       "license": "MIT"
     },
     "node_modules/convex": {
-      "version": "1.42.0",
-      "resolved": "https://registry.npmjs.org/convex/-/convex-1.42.0.tgz",
-      "integrity": "sha512-KS1U+YkE7N7jDfucPW28iNehnb9/N5n9RJmdAFNdPIHTeNpbLKNqk1pJHp4ajHyMBAhGmri8Z4S1lc1LjliZWQ==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/convex/-/convex-1.43.0.tgz",
+      "integrity": "sha512-huZWEUZQYxIRG104o22ZI99HkviSEVltwezZRDi+pQDPrQbc5EoCPa4Y7pJDqUBQw9dc/iEEXj2/rLZg1j7Dww==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6247,9 +6247,9 @@
       "dev": true
     },
     "convex": {
-      "version": "1.42.0",
-      "resolved": "https://registry.npmjs.org/convex/-/convex-1.42.0.tgz",
-      "integrity": "sha512-KS1U+YkE7N7jDfucPW28iNehnb9/N5n9RJmdAFNdPIHTeNpbLKNqk1pJHp4ajHyMBAhGmri8Z4S1lc1LjliZWQ==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/convex/-/convex-1.43.0.tgz",
+      "integrity": "sha512-huZWEUZQYxIRG104o22ZI99HkviSEVltwezZRDi+pQDPrQbc5EoCPa4Y7pJDqUBQw9dc/iEEXj2/rLZg1j7Dww==",
       "dev": true,
       "requires": {
         "esbuild": "0.27.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "author": "Sarah Shader & Michal Srb <srb@convex.dev>",
   "license": "Apache-2.0",
   "peerDependencies": {
-    "convex": "^1.32.0"
+    "convex": "^1.43.0"
   },
   "devDependencies": {
     "@edge-runtime/vm": "5.0.0",
@@ -47,7 +47,7 @@
     "@typescript-eslint/eslint-plugin": "8.58.2",
     "@typescript-eslint/parser": "8.58.2",
     "@vitest/coverage-v8": "1.6.1",
-    "convex": "1.42.0",
+    "convex": "1.43.0",
     "eslint": "9.39.4",
     "globals": "17.5.0",
     "pkg-pr-new": "0.0.66",


### PR DESCRIPTION
Emulates `db.vars.commitTs` and the `v.commitTs()` validator. 

A document in has two projections in an executing transaction:

- **as stored** — holds placeholder values like `CommitTsPlaceholder`, which is what user code reads
  back inside a writing mutation. 
- **pre-commit view** — the resolved value used for all comparison, ordering, and validation decisions.

Document comparisons funnel through `evaluateFieldPath` and query literals through a new `evaluateQueryValue`. Placeholder values get resolved for the outermost commit in `TransactionManager.commit`. 

