### PR TITLE
refactor: make test accessors composable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
   fetches data or waits on timers into the test body before calling these methods.
   Use actions for application code that needs these APIs; scheduling through
   `ctx.scheduler` remains supported.
+- The return value of `t.withIdentity(identity)` now has a `.withIdentity`
+  method itself, which also returns context for function calls for a particular
+  identity. We made that change because we will soon add more methods in
+  `TestConvexForDataModel`, and we want for these methods to be callable
+  in any order.
 
 ## 0.0.57
 

--- a/convex/authentication.test.ts
+++ b/convex/authentication.test.ts
@@ -15,6 +15,20 @@ test("generated attributes", async () => {
   expect(attributes!.subject).toBeTypeOf("string");
   expect(attributes!.issuer).toBeTypeOf("string");
 });
+test("accessors are immutable", async () => {
+  const t = convexTest(schema);
+  const asSarah = t.withIdentity({ name: "Sarah" });
+  // A narrowed accessor supports everything the original one does, including
+  // being narrowed again.
+  const asMichal = asSarah.withIdentity({ name: "Michal" });
+  const identity = (t: TestConvexForDataModel<DataModel>) =>
+    t.run((ctx) => ctx.auth.getUserIdentity());
+  expect(await identity(asMichal)).toMatchObject({ name: "Michal" });
+  // Neither of the accessors it was derived from is affected.
+  expect(await identity(asSarah)).toMatchObject({ name: "Sarah" });
+  expect(await identity(t)).toEqual(null);
+});
+
 async function runTest(
   fn: (t: TestConvexForDataModel<DataModel>) => Promise<string | null>,
 ) {

--- a/convex/typeAssignability.test.ts
+++ b/convex/typeAssignability.test.ts
@@ -1,7 +1,8 @@
 import { expect, test } from "vitest";
-import { convexTest, TestConvex } from "../index";
+import { convexTest, TestConvex, TestConvexForDataModel } from "../index";
 import schema from "./schema";
 import type { SchemaDefinition, GenericSchema } from "convex/server";
+import type { DataModel } from "./_generated/dataModel";
 
 // Reproduction: a library function that accepts a generic TestConvex
 // (like workflow.register does)
@@ -13,6 +14,18 @@ function registerComponent(
   void t;
   void name;
 }
+
+test("withIdentity returns an accessor that can be narrowed again", () => {
+  const t = convexTest(schema);
+  const asSarah: TestConvexForDataModel<DataModel> = t.withIdentity({
+    name: "Sarah",
+  });
+  const asMichal: TestConvexForDataModel<DataModel> = asSarah.withIdentity({
+    name: "Michal",
+  });
+  void asMichal;
+  expect(true).toBe(true);
+});
 
 test("TestConvex with specific schema is assignable to generic TestConvex", () => {
   const t = convexTest(schema);

--- a/index.ts
+++ b/index.ts
@@ -2065,15 +2065,15 @@ export type TestConvexForDataModel<DataModel extends GenericDataModel> = {
     advanceTimers: () => void,
     maxIterations?: number,
   ) => Promise<void>;
-};
 
-export type TestConvexForDataModelAndIdentity<
-  DataModel extends GenericDataModel,
-> = {
   /**
    * To test functions which depend on the current authenticated user identity
    * you can create a version of the `t` accessor with given user identity
    * attributes.
+   *
+   * The instance this is called on is not affected, and it is possible to call
+   * `withIdentity` on the returned value again to call functions with a new identity.
+   *
    * @param identity A subset of {@link UserIdentity} attributes. If you
    *   don't provide `issuer`, `subject` or `tokenIdentifier` they are
    *   generated automatically.
@@ -2081,6 +2081,15 @@ export type TestConvexForDataModelAndIdentity<
   withIdentity(
     identity: Partial<UserIdentity>,
   ): TestConvexForDataModel<DataModel>;
+};
+
+export type TestConvexForDataModelAndIdentity<
+  DataModel extends GenericDataModel,
+> = {
+  /**
+   * Register a component, so that the functions of the app under test can call
+   * it.
+   */
   registerComponent: (
     componentPath: string,
     schema: SchemaDefinition<GenericSchema, boolean>,
@@ -2664,32 +2673,37 @@ export function convexTest<Schema extends GenericSchema>(
     return result;
   }
 
-  return {
-    withIdentity(identity: Partial<UserIdentity>) {
-      const subject =
-        identity.subject ?? "" + simpleHash(JSON.stringify(identity));
-      const issuer = identity.issuer ?? "https://convex.test";
-      const tokenIdentifier =
-        identity.tokenIdentifier ?? `${issuer}|${subject}`;
-      return wrapInContext(
-        withAuth(
+  function registerComponent(
+    componentPath: string,
+    schema: SchemaDefinition<GenericSchema, boolean>,
+    glob: Record<string, () => Promise<any>>,
+  ) {
+    const componentInfo = {
+      db: new DatabaseFake(schema, componentPath),
+      modules: moduleCache(glob),
+    };
+    convexGlobal.components[componentPath] = componentInfo;
+  }
+
+  // Each accessor is immutable: `withIdentity` returns a new one instead of
+  // modifying the accessor it was called on.
+  function testAccessor(auth: AuthFake): any {
+    return {
+      ...wrapInContext(withAuth(auth)),
+      withIdentity(identity: Partial<UserIdentity>) {
+        const subject =
+          identity.subject ?? "" + simpleHash(JSON.stringify(identity));
+        const issuer = identity.issuer ?? "https://convex.test";
+        const tokenIdentifier =
+          identity.tokenIdentifier ?? `${issuer}|${subject}`;
+        return testAccessor(
           new AuthFake({ ...identity, subject, issuer, tokenIdentifier }),
-        ),
-      );
-    },
-    ...wrapInContext(withAuth()),
-    registerComponent(
-      componentPath: string,
-      schema: SchemaDefinition<GenericSchema, boolean>,
-      glob: Record<string, () => Promise<any>>,
-    ) {
-      const componentInfo = {
-        db: new DatabaseFake(schema, componentPath),
-        modules: moduleCache(glob),
-      };
-      convexGlobal.components[componentPath] = componentInfo;
-    },
-  } as any;
+        );
+      },
+    };
+  }
+
+  return { ...testAccessor(new AuthFake()), registerComponent };
 }
 
 // Yield through a full event loop iteration so that dynamic import()


### PR DESCRIPTION
Currently, when calling `t.withIdentity`, the return type of `withIdentity` doesn’t include `withIdentity`. This makes sense, because usually you don’t need to set the identity twice.

In this PR, I’m doing a small change that allows developers to call `withIdentity` on the return value of `withIdentity` itself, for instance:

```ts
const t = convexTest(schema);
const identity = (t: TestConvexForDataModel<DataModel>) =>
  t.run((ctx) => ctx.auth.getUserIdentity());

const asSarah = t.withIdentity({ name: "Sarah" });
const asMichal = asSarah.withIdentity({ name: "Michal" }); // 🆕

expect(await identity(asMichal)).toMatchObject({ name: "Michal" });
```

By itself, this change isn’t super helpful. The reason why I’m doing it is that I want to add new methods allowing developers to customize the calling context, like `.withRequestMetadata` (that I added in #134). We want to allow users to call `.withRequestMetadata` and `.withIdentity` in any order, so it’s simpler doing this type modification so that we don’t need to have complex types that ensure we call each method only once.

----

**Before this PR**

```mermaid
stateDiagram-v2
    [*] --> Initial

    state "<b>Initial</b><br/><br/>withIdentity()<br/>registerComponent()<br/>run()" as Initial

    state "<b>With Identity</b><br/><br/>run()" as Identity

    Initial --> Initial: registerComponent()
    Initial --> Identity: withIdentity()
```

**After this PR**

```mermaid
stateDiagram-v2
    [*] --> Initial

    state "<b>Initial</b><br/><br/>withIdentity()<br/>registerComponent()<br/>run()" as Initial

    state "<b>With Identity</b><br/><br/>withIdentity()<br/>run()" as Identity

    Initial --> Initial: registerComponent()
    Initial --> Identity: withIdentity()
    Identity --> Identity: withIdentity()
```

---

The alternative would be to build more complex types, like:

```mermaid
stateDiagram-v2
    [*] --> Initial

    state "<b>Initial</b><br/><br/>registerComponent()<br/>withIdentity()<br/>withRequestMetadata()<br/>run()" as Initial
    state "<b>With Identity</b><br/><br/>withRequestMetadata()<br/>run()" as Identity
    state "<b>With Request Metadata</b><br/><br/>withIdentity()<br/>run()" as Metadata
    state "<b>With Identity + Request Metadata</b><br/><br/>run()" as IdentityMetadata
    state "<b>With Request Metadata + Identity</b><br/><br/>run()" as MetadataIdentity

    Initial --> Initial: registerComponent()
    Initial --> Identity: withIdentity()
    Initial --> Metadata: withRequestMetadata()

    Identity --> IdentityMetadata: withRequestMetadata()
    Metadata --> MetadataIdentity: withIdentity()
```

…but this is more complex and doesn’t scale well as we add more `with*` methods, so I don’t think it’s worth doing it.