### PR TITLE
feat: implement ctx.meta.getRequestMetadata()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@
   identity. We made that change because we will soon add more methods in
   `TestConvexForDataModel`, and we want for these methods to be callable
   in any order.
+- Add implementation for `ctx.meta.getRequestMetadata()` in mutations, actions
+  and HTTP actions. Every call from the test starts a new request, and the
+  functions it calls share the request's `requestId`, components included.
+  Scheduled functions run as their own request, with their
+  `_scheduled_functions` document ID exposed as `scheduledFunctionId`.
 
 ## 0.0.57
 

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -27,6 +27,8 @@ import type * as mutations from "../mutations.js";
 import type * as nestedLimits from "../nestedLimits.js";
 import type * as pagination from "../pagination.js";
 import type * as queries from "../queries.js";
+import type * as requestMetadata from "../requestMetadata.js";
+import type * as requestMetadataNode from "../requestMetadataNode.js";
 import type * as returnsValidation from "../returnsValidation.js";
 import type * as scheduler from "../scheduler.js";
 import type * as storage from "../storage.js";
@@ -59,6 +61,8 @@ declare const fullApi: ApiFromModules<{
   nestedLimits: typeof nestedLimits;
   pagination: typeof pagination;
   queries: typeof queries;
+  requestMetadata: typeof requestMetadata;
+  requestMetadataNode: typeof requestMetadataNode;
   returnsValidation: typeof returnsValidation;
   scheduler: typeof scheduler;
   storage: typeof storage;

--- a/convex/counter/component/_generated/component.ts
+++ b/convex/counter/component/_generated/component.ts
@@ -89,6 +89,14 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         any,
         Name
       >;
+      requestMetadata: FunctionReference<"mutation", "internal", {}, any, Name>;
+      requestMetadataAction: FunctionReference<
+        "action",
+        "internal",
+        {},
+        any,
+        Name
+      >;
       schedule: FunctionReference<
         "mutation",
         "internal",

--- a/convex/counter/component/public.ts
+++ b/convex/counter/component/public.ts
@@ -116,6 +116,20 @@ export const mutationWithNumberArg = mutation({
   },
 });
 
+export const requestMetadata = mutation({
+  args: {},
+  handler: async (ctx) => {
+    return await ctx.meta.getRequestMetadata();
+  },
+});
+
+export const requestMetadataAction = action({
+  args: {},
+  handler: async (ctx) => {
+    return await ctx.meta.getRequestMetadata();
+  },
+});
+
 export const metadata = query({
   args: {},
   handler: async (ctx) => {

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -1,5 +1,5 @@
 import { httpRouter } from "convex/server";
-import { internal } from "./_generated/api";
+import { api, internal } from "./_generated/api";
 import { httpAction, internalQuery } from "./_generated/server";
 
 const http = httpRouter();
@@ -51,6 +51,18 @@ http.route({
   handler: httpAction(async (ctx) => {
     const metadata = await ctx.meta.getFunctionMetadata();
     return new Response(JSON.stringify(metadata), { status: 200 });
+  }),
+});
+
+http.route({
+  path: "/requestMetadata",
+  method: "GET",
+  handler: httpAction(async (ctx) => {
+    const metadata = await ctx.meta.getRequestMetadata();
+    const nested = await ctx.runMutation(api.requestMetadata.metadataMutation);
+    return new Response(JSON.stringify({ own: metadata, nested }), {
+      status: 200,
+    });
   }),
 });
 

--- a/convex/requestMetadata.test.ts
+++ b/convex/requestMetadata.test.ts
@@ -1,0 +1,176 @@
+/// <reference types="vite/client" />
+
+import { expect, test, vi } from "vitest";
+import { convexTest } from "../index";
+import schema from "./schema";
+import { api } from "./_generated/api";
+import counterSchema from "./counter/component/schema";
+
+const counterModules = import.meta.glob("./counter/component/**/*.ts");
+
+function testWithCounter() {
+  const t = convexTest(schema);
+  t.registerComponent("counter", counterSchema, counterModules);
+  return t;
+}
+
+// convex-test generates request IDs from a counter, so they are recognizably
+// fake rather than the backend's 16 lowercase hexadecimal characters.
+const REQUEST_ID = /^fake-request-id-\d+$/;
+
+const defaultMetadata = {
+  ip: null,
+  userAgent: null,
+  requestId: expect.stringMatching(REQUEST_ID),
+  scheduledFunctionId: null,
+  authToken: null,
+};
+
+test("default metadata in a mutation", async () => {
+  const t = convexTest(schema);
+  expect(await t.mutation(api.requestMetadata.metadataMutation)).toEqual(
+    defaultMetadata,
+  );
+});
+
+test("default metadata in an action", async () => {
+  const t = convexTest(schema);
+  expect(await t.action(api.requestMetadata.metadataAction)).toEqual(
+    defaultMetadata,
+  );
+});
+
+test("default metadata in inline functions", async () => {
+  const t = convexTest(schema);
+  expect(
+    await t.mutation(async (ctx) => await ctx.meta.getRequestMetadata()),
+  ).toEqual(defaultMetadata);
+  expect(
+    await t.action(async (ctx) => await ctx.meta.getRequestMetadata()),
+  ).toEqual(defaultMetadata);
+  expect(
+    await t.run(async (ctx) => await ctx.meta.getRequestMetadata()),
+  ).toEqual(defaultMetadata);
+});
+
+test("not available in queries", async () => {
+  const t = convexTest(schema);
+  await expect(t.query(api.requestMetadata.metadataQuery)).rejects.toThrow(
+    "not available in queries",
+  );
+});
+
+test("each top-level call gets its own request ID", async () => {
+  const t = convexTest(schema);
+  const first = await t.mutation(api.requestMetadata.metadataMutation);
+  const second = await t.mutation(api.requestMetadata.metadataMutation);
+  const third = await t.action(api.requestMetadata.metadataAction);
+  expect(new Set([first, second, third].map((m) => m.requestId)).size).toEqual(
+    3,
+  );
+});
+
+test("nested calls share the request metadata", async () => {
+  const t = testWithCounter();
+  const { own, component } = await t.mutation(
+    api.requestMetadata.mutationCallingMutation,
+  );
+  const recorded = await t.query(api.requestMetadata.recorded);
+  expect(recorded.map(({ label }) => label)).toEqual(["nested"]);
+  expect(recorded[0].metadata).toEqual(own);
+  // Request metadata propagates into components, unlike the identity.
+  expect(component).toEqual(own);
+});
+
+test("nested calls from an action share the request metadata", async () => {
+  const t = testWithCounter();
+  const { own, component } = await t.action(
+    api.requestMetadata.actionCallingFunctions,
+  );
+  const recorded = await t.query(api.requestMetadata.recorded);
+  expect(recorded.map(({ label }) => label)).toEqual([
+    "mutationFromAction",
+    "actionFromAction",
+  ]);
+  for (const { metadata } of recorded) {
+    expect(metadata).toEqual(own);
+  }
+  expect(component).toEqual(own);
+});
+
+test("Node action", async () => {
+  const t = convexTest(schema);
+  const metadata = await t.action(api.requestMetadataNode.metadataAction);
+  expect(metadata).toEqual(defaultMetadata);
+  const recorded = await t.query(api.requestMetadata.recorded);
+  expect(recorded[0].metadata).toEqual(metadata);
+});
+
+test("HTTP action", async () => {
+  const t = convexTest(schema);
+  const response = await t.fetch("/requestMetadata");
+  const { own, nested } = await response.json();
+  expect(own).toEqual(defaultMetadata);
+  expect(nested).toEqual(own);
+});
+
+test("each HTTP request gets its own request ID", async () => {
+  const t = convexTest(schema);
+  const first = await (await t.fetch("/requestMetadata")).json();
+  const second = await (await t.fetch("/requestMetadata")).json();
+  expect(first.own.requestId).not.toEqual(second.own.requestId);
+});
+
+test("scheduled mutation", async () => {
+  vi.useFakeTimers();
+  const t = convexTest(schema);
+  const caller = await t.mutation(api.requestMetadata.scheduleMutation);
+  await t.finishAllScheduledFunctions(vi.runAllTimers);
+  vi.useRealTimers();
+
+  const recorded = await t.query(api.requestMetadata.recorded);
+  expect(recorded.map(({ label }) => label)).toEqual([
+    "scheduledMutation",
+    "nestedInScheduledMutation",
+  ]);
+  const [scheduled, nested] = recorded.map(({ metadata }) => metadata);
+  // The scheduled function is its own request, not the caller's.
+  expect(scheduled.requestId).not.toEqual(caller.requestId);
+  expect(scheduled.requestId).toEqual(expect.stringMatching(REQUEST_ID));
+  const jobs = await t.run(async (ctx) =>
+    ctx.db.system.query("_scheduled_functions").collect(),
+  );
+  expect(scheduled.scheduledFunctionId).toEqual(jobs[0]._id);
+  // The functions the scheduled function calls belong to the same request.
+  expect(nested).toEqual(scheduled);
+});
+
+test("scheduled action scheduling another function", async () => {
+  vi.useFakeTimers();
+  const t = convexTest(schema);
+  await t.mutation(api.requestMetadata.scheduleAction);
+  await t.finishAllScheduledFunctions(vi.runAllTimers);
+  vi.useRealTimers();
+
+  const recorded = await t.query(api.requestMetadata.recorded);
+  expect(recorded.map(({ label }) => label)).toEqual([
+    "nestedInScheduledAction",
+    "scheduledMutation",
+    "nestedInScheduledMutation",
+  ]);
+  const [fromAction, scheduled, nestedInScheduled] = recorded.map(
+    ({ metadata }) => metadata,
+  );
+  // The function scheduled by the scheduled action is its own request.
+  expect(scheduled.requestId).not.toEqual(fromAction.requestId);
+  expect(scheduled.scheduledFunctionId).not.toEqual(
+    fromAction.scheduledFunctionId,
+  );
+  expect(nestedInScheduled).toEqual(scheduled);
+});
+
+test("functions that were not scheduled have no scheduled function ID", async () => {
+  const t = convexTest(schema);
+  const metadata = await t.mutation(api.requestMetadata.metadataMutation);
+  expect(metadata.scheduledFunctionId).toEqual(null);
+});

--- a/convex/requestMetadata.ts
+++ b/convex/requestMetadata.ts
@@ -1,0 +1,132 @@
+import { v } from "convex/values";
+import { api, components } from "./_generated/api";
+import { action, mutation, query } from "./_generated/server";
+
+export const metadataMutation = mutation({
+  args: {},
+  handler: async (ctx) => {
+    return await ctx.meta.getRequestMetadata();
+  },
+});
+
+export const metadataAction = action({
+  args: {},
+  handler: async (ctx) => {
+    return await ctx.meta.getRequestMetadata();
+  },
+});
+
+// `getRequestMetadata` is not part of a query's `ctx.meta`, so the syscall
+// has to be called directly to check that queries are rejected.
+export const metadataQuery = query({
+  args: {},
+  handler: async () => {
+    const syscalls = (globalThis as any).Convex;
+    return JSON.parse(
+      await syscalls.asyncSyscall("1.0/getRequestMetadata", JSON.stringify({})),
+    );
+  },
+});
+
+// Records the metadata of the function execution it runs in, so that
+// executions that don't return to the test (like scheduled functions) can be
+// inspected afterwards.
+export const record = mutation({
+  args: { label: v.string() },
+  returns: v.null(),
+  handler: async (ctx, { label }) => {
+    await ctx.db.insert("requestMetadata", {
+      label,
+      metadata: await ctx.meta.getRequestMetadata(),
+    });
+    return null;
+  },
+});
+
+export const recorded = query({
+  args: {},
+  handler: async (ctx) => {
+    return await ctx.db.query("requestMetadata").collect();
+  },
+});
+
+export const mutationCallingMutation = mutation({
+  args: {},
+  handler: async (ctx) => {
+    await ctx.runMutation(api.requestMetadata.record, { label: "nested" });
+    const component = await ctx.runMutation(
+      components.counter.public.requestMetadata,
+      {},
+    );
+    return { own: await ctx.meta.getRequestMetadata(), component };
+  },
+});
+
+export const actionCallingFunctions = action({
+  args: {},
+  handler: async (ctx) => {
+    await ctx.runMutation(api.requestMetadata.record, {
+      label: "mutationFromAction",
+    });
+    await ctx.runAction(api.requestMetadata.actionRecordingMetadata, {
+      label: "actionFromAction",
+    });
+    const component = await ctx.runAction(
+      components.counter.public.requestMetadataAction,
+      {},
+    );
+    return { own: await ctx.meta.getRequestMetadata(), component };
+  },
+});
+
+export const actionRecordingMetadata = action({
+  args: { label: v.string() },
+  returns: v.null(),
+  handler: async (ctx, { label }): Promise<null> => {
+    await ctx.runMutation(api.requestMetadata.record, { label });
+    return null;
+  },
+});
+
+export const scheduleMutation = mutation({
+  args: {},
+  handler: async (ctx) => {
+    await ctx.scheduler.runAfter(0, api.requestMetadata.scheduledMutation, {});
+    return await ctx.meta.getRequestMetadata();
+  },
+});
+
+export const scheduledMutation = mutation({
+  args: {},
+  returns: v.null(),
+  handler: async (ctx): Promise<null> => {
+    await ctx.db.insert("requestMetadata", {
+      label: "scheduledMutation",
+      metadata: await ctx.meta.getRequestMetadata(),
+    });
+    await ctx.runMutation(api.requestMetadata.record, {
+      label: "nestedInScheduledMutation",
+    });
+    return null;
+  },
+});
+
+export const scheduleAction = mutation({
+  args: {},
+  handler: async (ctx) => {
+    await ctx.scheduler.runAfter(0, api.requestMetadata.scheduledAction, {});
+    return await ctx.meta.getRequestMetadata();
+  },
+});
+
+export const scheduledAction = action({
+  args: {},
+  returns: v.null(),
+  handler: async (ctx): Promise<null> => {
+    await ctx.runMutation(api.requestMetadata.record, {
+      label: "nestedInScheduledAction",
+    });
+    await ctx.scheduler.runAfter(0, api.requestMetadata.scheduledMutation, {});
+    return null;
+  },
+});

--- a/convex/requestMetadataNode.ts
+++ b/convex/requestMetadataNode.ts
@@ -1,0 +1,14 @@
+"use node";
+
+import { api } from "./_generated/api";
+import { action } from "./_generated/server";
+
+export const metadataAction = action({
+  args: {},
+  handler: async (ctx) => {
+    await ctx.runMutation(api.requestMetadata.record, {
+      label: "mutationFromNodeAction",
+    });
+    return await ctx.meta.getRequestMetadata();
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -9,6 +9,16 @@ export default defineSchema({
     nested: v.optional(v.object({ commitTs: v.commitTs() })),
     other: v.optional(v.string()),
   }).index("by_commit_ts", ["commitTs"]),
+  requestMetadata: defineTable({
+    label: v.string(),
+    metadata: v.object({
+      ip: v.union(v.string(), v.null()),
+      userAgent: v.union(v.string(), v.null()),
+      requestId: v.string(),
+      scheduledFunctionId: v.union(v.string(), v.null()),
+      authToken: v.union(v.string(), v.null()),
+    }),
+  }),
   messages: defineTable({
     author: v.string(),
     body: v.string(),

--- a/index.ts
+++ b/index.ts
@@ -1442,55 +1442,67 @@ async function runScheduledFunction({
   args: Value;
   name: string;
 }) {
-  await authStorage.run(new AuthFake(), async () => {
-    const canceled = await withAuth().runInComponent(
-      componentPath,
-      async () => {
-        const job = db.get("_scheduled_functions", jobId) as
-          | ScheduledFunction
-          | undefined;
-        if (!job) return true;
-        if (job.state.kind === "canceled") {
-          return true;
-        }
-        if (job.state.kind !== "pending") {
+  // A scheduled function is its own request: it doesn't inherit the request
+  // metadata of whoever scheduled it, and it identifies itself through its
+  // job ID.
+  const requestMetadata: RequestMetadataFake = {
+    ip: null,
+    userAgent: null,
+    requestId: newRequestId(),
+    scheduledFunctionId: jobId,
+    authToken: null,
+  };
+  await requestMetadataStorage.run(requestMetadata, () =>
+    authStorage.run(new AuthFake(), async () => {
+      const canceled = await withAuth().runInComponent(
+        componentPath,
+        async () => {
+          const job = db.get("_scheduled_functions", jobId) as
+            | ScheduledFunction
+            | undefined;
+          if (!job) return true;
+          if (job.state.kind === "canceled") {
+            return true;
+          }
+          if (job.state.kind !== "pending") {
+            throw new Error(
+              `\`convexTest\` invariant error: Unexpected scheduled function state when starting it: ${job.state.kind}`,
+            );
+          }
+          db.patch("_scheduled_functions", jobId, {
+            state: { kind: "inProgress" },
+          });
+          return false;
+        },
+      );
+      if (canceled) {
+        return;
+      }
+      try {
+        await withAuth().fun(functionPath, args);
+      } catch (error) {
+        console.error(`Error when running scheduled function ${name}`, error);
+        await withAuth().runInComponent(componentPath, async () => {
+          db.patch("_scheduled_functions", jobId, {
+            state: { kind: "failed" },
+            completedTime: Date.now(),
+          });
+        });
+        return;
+      }
+      await withAuth().runInComponent(componentPath, async () => {
+        const job = db.get("_scheduled_functions", jobId) as ScheduledFunction;
+        if (job.state.kind !== "inProgress") {
           throw new Error(
-            `\`convexTest\` invariant error: Unexpected scheduled function state when starting it: ${job.state.kind}`,
+            `\`convexTest\` invariant error: Unexpected scheduled function state after it finished running: ${job.state.kind}`,
           );
         }
         db.patch("_scheduled_functions", jobId, {
-          state: { kind: "inProgress" },
-        });
-        return false;
-      },
-    );
-    if (canceled) {
-      return;
-    }
-    try {
-      await withAuth().fun(functionPath, args);
-    } catch (error) {
-      console.error(`Error when running scheduled function ${name}`, error);
-      await withAuth().runInComponent(componentPath, async () => {
-        db.patch("_scheduled_functions", jobId, {
-          state: { kind: "failed" },
-          completedTime: Date.now(),
+          state: { kind: "success" },
         });
       });
-      return;
-    }
-    await withAuth().runInComponent(componentPath, async () => {
-      const job = db.get("_scheduled_functions", jobId) as ScheduledFunction;
-      if (job.state.kind !== "inProgress") {
-        throw new Error(
-          `\`convexTest\` invariant error: Unexpected scheduled function state after it finished running: ${job.state.kind}`,
-        );
-      }
-      db.patch("_scheduled_functions", jobId, {
-        state: { kind: "success" },
-      });
-    });
-  });
+    }),
+  );
 }
 
 function asyncSyscallImpl() {
@@ -1617,6 +1629,24 @@ function asyncSyscallImpl() {
             componentPath: ctx.componentPath,
           }),
         );
+      }
+      case "1.0/getRequestMetadata": {
+        const ctx = executionContextStorage.getStore();
+        const requestMetadata = requestMetadataStorage.getStore();
+        if (ctx === undefined || requestMetadata === undefined) {
+          throw new Error(
+            "getRequestMetadata() can only be called from a mutation, action " +
+              "or HTTP action. It is not available in queries or outside of a " +
+              "Convex function.",
+          );
+        }
+        if (ctx.udfType === "query") {
+          throw new Error(
+            "getRequestMetadata() can only be called from a mutation, action " +
+              "or HTTP action. It is not available in queries.",
+          );
+        }
+        return JSON.stringify(convexToJson(requestMetadata));
       }
       case "1.0/getDeploymentMetadata": {
         return JSON.stringify(
@@ -2202,9 +2232,12 @@ type FunctionPath = {
   udfPath: string;
 };
 
+type UdfType = "query" | "mutation" | "action" | "http";
+
 type ExecutionContext = {
   componentPath: string;
   udfPath: string;
+  udfType: UdfType;
   depth: number; // 0 = top-level, 1+ = nested
   // Number of paginated queries (`.paginate()`) executed so far in this
   // function execution. Convex only allows one per function invocation.
@@ -2212,6 +2245,29 @@ type ExecutionContext = {
 };
 
 const executionContextStorage = new AsyncLocalStorage<ExecutionContext>();
+
+type RequestMetadataFake = {
+  ip: string | null;
+  userAgent: string | null;
+  requestId: string;
+  scheduledFunctionId: string | null;
+  authToken: string | null;
+};
+
+// The request metadata of the innermost top-level function execution. Nested
+// calls (including calls into components) inherit it, so it is only created
+// when a function is called from the test itself, and replaced when a
+// scheduled function starts.
+const requestMetadataStorage = new AsyncLocalStorage<RequestMetadataFake>();
+
+// Request IDs are internal bookkeeping. Generating them must not consume a
+// handler's mocked randomness, so they come from a counter instead of `crypto`
+// or `Math.random`. The prefix marks these as test-only IDs.
+let nextRequestId = 0;
+
+function newRequestId() {
+  return `fake-request-id-${nextRequestId++}`;
+}
 
 type ConvexGlobal = {
   components: Record<string, ComponentInfo>;
@@ -2738,10 +2794,6 @@ function yieldThroughRealTimers(): Promise<void> {
   return new Promise<void>((r) => realSetTimeout(r, 0));
 }
 
-// Request IDs are internal bookkeeping. Generating them must not consume a
-// handler's mocked Math.random sequence. The prefix marks these as test-only IDs.
-let nextRequestId = 0;
-
 function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
   // Auth doesn't propagate across component boundaries.
   function authForComponent(componentPath: string) {
@@ -2749,6 +2801,20 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
     const isCrossComponent =
       ctx !== undefined && componentPath !== ctx.componentPath;
     return isCrossComponent ? new AuthFake() : auth;
+  }
+
+  // Nested calls, including calls into components, run as part of the request
+  // that triggered the outermost function, so they share its metadata.
+  function requestMetadataForExecution(): RequestMetadataFake {
+    return (
+      requestMetadataStorage.getStore() ?? {
+        ip: null,
+        userAgent: null,
+        requestId: newRequestId(),
+        scheduledFunctionId: null,
+        authToken: null,
+      }
+    );
   }
 
   const runMutationWithHandler = async <T>(
@@ -2779,9 +2845,11 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
     const childCtx: ExecutionContext = {
       componentPath: functionPath.componentPath,
       udfPath: functionPath.udfPath,
+      udfType: "mutation",
       depth: (parentCtx?.depth ?? 0) + 1,
       paginatedQueries: 0,
     };
+    const requestMetadata = requestMetadataForExecution();
 
     await transactionManager.begin(isNested, transactionLimits);
     try {
@@ -2794,7 +2862,9 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
         ).invokeMutation(JSON.stringify(convexToJson([parseArgs(args)])));
       const invokeInContext = () =>
         executionContextStorage.run(childCtx, () =>
-          authStorage.run(authForChild, invokeRaw),
+          requestMetadataStorage.run(requestMetadata, () =>
+            authStorage.run(authForChild, invokeRaw),
+          ),
         );
 
       const rawResult = await nestedTxStorage.run(childLock, invokeInContext);
@@ -2836,9 +2906,11 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
     const childCtx: ExecutionContext = {
       componentPath: functionPath.componentPath,
       udfPath: functionPath.udfPath,
+      udfType: "query",
       depth: (parentCtx?.depth ?? 0) + 1,
       paginatedQueries: 0,
     };
+    const requestMetadata = requestMetadataForExecution();
 
     await transactionManager.begin(isNested, transactionLimits);
     try {
@@ -2849,7 +2921,9 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
         ).invokeQuery(JSON.stringify(convexToJson([parseArgs(args)])));
       const invokeInContext = () =>
         executionContextStorage.run(childCtx, () =>
-          authStorage.run(authForChild, invokeRaw),
+          requestMetadataStorage.run(requestMetadata, () =>
+            authStorage.run(authForChild, invokeRaw),
+          ),
         );
 
       const rawResult = await nestedTxStorage.run(childLock, invokeInContext);
@@ -2898,24 +2972,29 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
     const childCtx: ExecutionContext = {
       componentPath: functionPath.componentPath,
       udfPath: functionPath.udfPath,
+      udfType: "action",
       depth: (parentCtx?.depth ?? 0) + 1,
       paginatedQueries: 0,
     };
+    const requestMetadata = requestMetadataForExecution();
     return await executionContextStorage.run(childCtx, async () => {
-      const requestId = `fake-request-id-${nextRequestId++}`;
       try {
-        const rawResult = await authStorage.run(authForChild, () =>
-          (
-            a as unknown as {
-              invokeAction: (
-                requestId: string,
-                args: string,
-              ) => Promise<string>;
-            }
-          ).invokeAction(
-            requestId,
-            JSON.stringify(convexToJson([parseArgs(args)])),
-          ),
+        const rawResult = await requestMetadataStorage.run(
+          requestMetadata,
+          () =>
+            authStorage.run(authForChild, () =>
+              (
+                a as unknown as {
+                  invokeAction: (
+                    requestId: string,
+                    args: string,
+                  ) => Promise<string>;
+                }
+              ).invokeAction(
+                requestMetadata.requestId,
+                JSON.stringify(convexToJson([parseArgs(args)])),
+              ),
+            ),
         );
         return jsonToConvex(JSON.parse(rawResult)) as T;
       } catch (e) {
@@ -3178,13 +3257,18 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
         );
       },
     });
-    const requestId = `fake-request-id-${nextRequestId++}`;
+    const requestMetadata = requestMetadataForExecution();
     try {
-      const rawResult = await (
-        a as unknown as {
-          invokeAction: (requestId: string, args: string) => Promise<string>;
-        }
-      ).invokeAction(requestId, JSON.stringify(convexToJson([{}])));
+      const rawResult = await requestMetadataStorage.run(requestMetadata, () =>
+        (
+          a as unknown as {
+            invokeAction: (requestId: string, args: string) => Promise<string>;
+          }
+        ).invokeAction(
+          requestMetadata.requestId,
+          JSON.stringify(convexToJson([{}])),
+        ),
+      );
       return jsonToConvex(JSON.parse(rawResult)) as T;
     } catch (e) {
       throw deserializeConvexErrorData(e);
@@ -3240,15 +3324,19 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
       const httpCtx: ExecutionContext = {
         componentPath: getCurrentComponentPath(),
         udfPath: "http",
+        udfType: "http",
         depth: 0,
         paginatedQueries: 0,
       };
+      const requestMetadata = requestMetadataForExecution();
       const response = await executionContextStorage.run(httpCtx, () =>
-        (
-          a as unknown as {
-            invokeHttpAction: (request: Request) => Promise<Response>;
-          }
-        ).invokeHttpAction(new Request(url, init)),
+        requestMetadataStorage.run(requestMetadata, () =>
+          (
+            a as unknown as {
+              invokeHttpAction: (request: Request) => Promise<Response>;
+            }
+          ).invokeHttpAction(new Request(url, init)),
+        ),
       );
       return response;
     },


### PR DESCRIPTION
This PR implements the `1.0/getRequestMetadata` syscall in convex-test, so mutations, actions and HTTP actions can call `ctx.meta.getRequestMetadata()`.

It is rejected in queries, matching the backend, where a query's `ctx.meta` doesn't have it.

We use the following data in the return value:

| Field                 | Value in `convex-test`                                                                                                                |
| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
| `requestId`           | `fake-request-id-<n>` from a counter, one per top-level call from the test / scheduled function execution                                |
| `scheduledFunctionId` | `null` for anything called directly from the test; the `_scheduled_functions` document ID for a scheduled run and everything it calls |
| `ip`                  | Always `null` for now (will be customizable through `withRequestMetadata` in #135)                                                    |
| `userAgent`           | Always `null` for now (will be customizable through `withRequestMetadata` in #135)                                                    |
| `authToken`           | Always `null` for now (#136 modifies this to generate a fake auth token when using `withIdentity` instead)                            |

