### PR TITLE
feat: add t.withRequestMetadata for the IP and user agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
   functions it calls share the request's `requestId`, components included.
   Scheduled functions run as their own request, with their
   `_scheduled_functions` document ID exposed as `scheduledFunctionId`.
+- Add `t.withRequestMetadata({ ip, userAgent })`, which returns an accessor
+  whose calls report the given IP address and user agent.
 
 ## 0.0.57
 

--- a/convex/requestMetadata.test.ts
+++ b/convex/requestMetadata.test.ts
@@ -60,6 +60,76 @@ test("not available in queries", async () => {
   );
 });
 
+test("IP and user agent", async () => {
+  const t = convexTest(schema).withRequestMetadata({
+    ip: "1.2.3.4",
+    userAgent: "Mozilla/5.0",
+  });
+  expect(await t.mutation(api.requestMetadata.metadataMutation)).toEqual({
+    ...defaultMetadata,
+    ip: "1.2.3.4",
+    userAgent: "Mozilla/5.0",
+  });
+  expect(await t.action(api.requestMetadata.metadataAction)).toEqual({
+    ...defaultMetadata,
+    ip: "1.2.3.4",
+    userAgent: "Mozilla/5.0",
+  });
+});
+
+test("omitted request attributes are null", async () => {
+  const t = convexTest(schema).withRequestMetadata({ ip: "1.2.3.4" });
+  expect(await t.mutation(api.requestMetadata.metadataMutation)).toEqual({
+    ...defaultMetadata,
+    ip: "1.2.3.4",
+  });
+  // Calling the method again replaces both attributes.
+  const t2 = t.withRequestMetadata({ userAgent: "Mozilla/5.0" });
+  expect(await t2.mutation(api.requestMetadata.metadataMutation)).toEqual({
+    ...defaultMetadata,
+    userAgent: "Mozilla/5.0",
+  });
+});
+
+test("the accessor it was called on is not affected", async () => {
+  const t = convexTest(schema);
+  const withMetadata = t.withRequestMetadata({ ip: "1.2.3.4" });
+  expect(
+    await withMetadata.mutation(api.requestMetadata.metadataMutation),
+  ).toMatchObject({ ip: "1.2.3.4" });
+  expect(await t.mutation(api.requestMetadata.metadataMutation)).toMatchObject({
+    ip: null,
+  });
+});
+
+test("accessors with different metadata used in parallel", async () => {
+  const t = convexTest(schema);
+  const [first, second] = await Promise.all([
+    t
+      .withRequestMetadata({ ip: "1.2.3.4" })
+      .mutation(api.requestMetadata.metadataMutation),
+    t
+      .withRequestMetadata({ ip: "5.6.7.8", userAgent: "Firefox" })
+      .mutation(api.requestMetadata.metadataMutation),
+  ]);
+  expect(first).toMatchObject({ ip: "1.2.3.4", userAgent: null });
+  expect(second).toMatchObject({ ip: "5.6.7.8", userAgent: "Firefox" });
+});
+
+test("the IP and user agent propagate to nested calls", async () => {
+  const t = testWithCounter().withRequestMetadata({
+    ip: "1.2.3.4",
+    userAgent: "Mozilla/5.0",
+  });
+  const { own, component } = await t.mutation(
+    api.requestMetadata.mutationCallingMutation,
+  );
+  expect(own).toMatchObject({ ip: "1.2.3.4", userAgent: "Mozilla/5.0" });
+  expect(component).toEqual(own);
+  const recorded = await t.query(api.requestMetadata.recorded);
+  expect(recorded[0].metadata).toEqual(own);
+});
+
 test("each top-level call gets its own request ID", async () => {
   const t = convexTest(schema);
   const first = await t.mutation(api.requestMetadata.metadataMutation);
@@ -107,11 +177,30 @@ test("Node action", async () => {
 });
 
 test("HTTP action", async () => {
-  const t = convexTest(schema);
+  const t = convexTest(schema).withRequestMetadata({
+    ip: "1.2.3.4",
+    userAgent: "Mozilla/5.0",
+  });
   const response = await t.fetch("/requestMetadata");
   const { own, nested } = await response.json();
-  expect(own).toEqual(defaultMetadata);
+  expect(own).toEqual({
+    ...defaultMetadata,
+    ip: "1.2.3.4",
+    userAgent: "Mozilla/5.0",
+  });
   expect(nested).toEqual(own);
+});
+
+test("HTTP request headers do not set the request metadata", async () => {
+  const t = convexTest(schema);
+  const response = await t.fetch("/requestMetadata", {
+    headers: {
+      "X-Forwarded-For": "1.2.3.4",
+      "User-Agent": "Mozilla/5.0",
+    },
+  });
+  const { own } = await response.json();
+  expect(own).toMatchObject({ ip: null, userAgent: null });
 });
 
 test("each HTTP request gets its own request ID", async () => {
@@ -124,7 +213,9 @@ test("each HTTP request gets its own request ID", async () => {
 test("scheduled mutation", async () => {
   vi.useFakeTimers();
   const t = convexTest(schema);
-  const caller = await t.mutation(api.requestMetadata.scheduleMutation);
+  const caller = await t
+    .withRequestMetadata({ ip: "1.2.3.4", userAgent: "Mozilla/5.0" })
+    .mutation(api.requestMetadata.scheduleMutation);
   await t.finishAllScheduledFunctions(vi.runAllTimers);
   vi.useRealTimers();
 
@@ -134,9 +225,16 @@ test("scheduled mutation", async () => {
     "nestedInScheduledMutation",
   ]);
   const [scheduled, nested] = recorded.map(({ metadata }) => metadata);
-  // The scheduled function is its own request, not the caller's.
+  // The scheduled function is its own request: none of the caller's data
+  // reaches it.
+  expect(scheduled).toEqual({
+    ip: null,
+    userAgent: null,
+    requestId: expect.stringMatching(REQUEST_ID),
+    scheduledFunctionId: expect.any(String),
+    authToken: null,
+  });
   expect(scheduled.requestId).not.toEqual(caller.requestId);
-  expect(scheduled.requestId).toEqual(expect.stringMatching(REQUEST_ID));
   const jobs = await t.run(async (ctx) =>
     ctx.db.system.query("_scheduled_functions").collect(),
   );

--- a/convex/typeAssignability.test.ts
+++ b/convex/typeAssignability.test.ts
@@ -27,6 +27,21 @@ test("withIdentity returns an accessor that can be narrowed again", () => {
   expect(true).toBe(true);
 });
 
+test("withIdentity and withRequestMetadata can be called in either order", () => {
+  const t = convexTest(schema);
+  // Both orders produce an accessor, so neither method loses what the other
+  // one configured.
+  const identityFirst: TestConvexForDataModel<DataModel> = t
+    .withIdentity({ name: "Sarah" })
+    .withRequestMetadata({ ip: "1.2.3.4" });
+  const requestFirst: TestConvexForDataModel<DataModel> = t
+    .withRequestMetadata({ ip: "1.2.3.4" })
+    .withIdentity({ name: "Sarah" });
+  void identityFirst;
+  void requestFirst;
+  expect(true).toBe(true);
+});
+
 test("TestConvex with specific schema is assignable to generic TestConvex", () => {
   const t = convexTest(schema);
   // This is the call that fails with the overloaded call signature approach

--- a/index.ts
+++ b/index.ts
@@ -19,6 +19,7 @@ import {
   RegisteredAction,
   RegisteredMutation,
   RegisteredQuery,
+  RequestMetadata,
   SchemaDefinition,
   SystemDataModel,
   UserIdentity,
@@ -2111,6 +2112,20 @@ export type TestConvexForDataModel<DataModel extends GenericDataModel> = {
   withIdentity(
     identity: Partial<UserIdentity>,
   ): TestConvexForDataModel<DataModel>;
+  /**
+   * To test functions which depend on the metadata of the request that
+   * triggered them, available via `ctx.meta.getRequestMetadata()`, you can
+   * create a version of the `t` accessor with a given IP address and user
+   * agent.
+   *
+   * Attributes that aren't provided are `null`, and calling this method again
+   * replaces both of them.
+   *
+   * @param metadata The `ip` and `userAgent` of the request.
+   */
+  withRequestMetadata(
+    metadata: Partial<Pick<RequestMetadata, "ip" | "userAgent">>,
+  ): TestConvexForDataModel<DataModel>;
 };
 
 /**
@@ -2259,6 +2274,12 @@ type RequestMetadataFake = {
 // when a function is called from the test itself, and replaced when a
 // scheduled function starts.
 const requestMetadataStorage = new AsyncLocalStorage<RequestMetadataFake>();
+
+// The request attributes a test accessor was configured with, which only
+// apply to the functions the accessor itself calls.
+type RequestOptions = { ip: string | null; userAgent: string | null };
+
+const DEFAULT_REQUEST_OPTIONS: RequestOptions = { ip: null, userAgent: null };
 
 // Request IDs are internal bookkeeping. Generating them must not consume a
 // handler's mocked randomness, so they come from a counter instead of `crypto`
@@ -2750,11 +2771,12 @@ export function convexTest<Schema extends GenericSchema>(
     convexGlobal.components[componentPath] = componentInfo;
   }
 
-  // Each accessor is immutable: `withIdentity` returns a new one instead of
-  // modifying the accessor it was called on.
-  function testAccessor(auth: AuthFake): any {
+  // Each accessor is immutable: `withIdentity` and `withRequestMetadata`
+  // return a new one, keeping what the other method configured, so they can be
+  // called in either order.
+  function testAccessor(auth: AuthFake, requestOptions: RequestOptions): any {
     return {
-      ...wrapInContext(withAuth(auth)),
+      ...wrapInContext(withAuth(auth, requestOptions)),
       withIdentity(identity: Partial<UserIdentity>) {
         const subject =
           identity.subject ?? "" + simpleHash(JSON.stringify(identity));
@@ -2763,12 +2785,24 @@ export function convexTest<Schema extends GenericSchema>(
           identity.tokenIdentifier ?? `${issuer}|${subject}`;
         return testAccessor(
           new AuthFake({ ...identity, subject, issuer, tokenIdentifier }),
+          requestOptions,
         );
+      },
+      withRequestMetadata(
+        metadata: Partial<Pick<RequestMetadata, "ip" | "userAgent">>,
+      ) {
+        return testAccessor(auth, {
+          ip: metadata.ip ?? null,
+          userAgent: metadata.userAgent ?? null,
+        });
       },
     };
   }
 
-  return { ...testAccessor(new AuthFake()), registerComponent };
+  return {
+    ...testAccessor(new AuthFake(), DEFAULT_REQUEST_OPTIONS),
+    registerComponent,
+  };
 }
 
 // Yield through a full event loop iteration so that dynamic import()
@@ -2794,7 +2828,10 @@ function yieldThroughRealTimers(): Promise<void> {
   return new Promise<void>((r) => realSetTimeout(r, 0));
 }
 
-function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
+function withAuth(
+  auth: AuthFake = authStorage.getStore() ?? new AuthFake(),
+  requestOptions: RequestOptions = DEFAULT_REQUEST_OPTIONS,
+) {
   // Auth doesn't propagate across component boundaries.
   function authForComponent(componentPath: string) {
     const ctx = executionContextStorage.getStore();
@@ -2808,8 +2845,8 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
   function requestMetadataForExecution(): RequestMetadataFake {
     return (
       requestMetadataStorage.getStore() ?? {
-        ip: null,
-        userAgent: null,
+        ip: requestOptions.ip,
+        userAgent: requestOptions.userAgent,
         requestId: newRequestId(),
         scheduledFunctionId: null,
         authToken: null,
@@ -3328,6 +3365,8 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
         depth: 0,
         paginatedQueries: 0,
       };
+      // The request's headers are not inspected: like the identity, the IP and
+      // the user agent are configured on the test accessor.
       const requestMetadata = requestMetadataForExecution();
       const response = await executionContextStorage.run(httpCtx, () =>
         requestMetadataStorage.run(requestMetadata, () =>


### PR DESCRIPTION
This PR adds a new method, `t.withRequestMetadata({ ip, userAgent })` which can be used to perform convex-test function calls with a custom IP address and user agent.

Both `ip` and `userAgent` are optional, and treated as null if not provided.

`t.fetch` deliberately ignores the request's headers: in browser `fetch` calls, these headers can’t be set from the `fetch` call headers.