### PR TITLE
fix: reject unsupported function args validators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Reject function `args` validators that aren't an object or `v.any()`, matching
+  the error the real backend raises at push time. Previously e.g. a top-level
+  `v.union(...)` args validator worked in tests but failed to deploy.
+
 ## 0.0.56
 
 - Document the second parameter to `finishAllScheduledFunctions`

--- a/convex/argumentsValidation.test.ts
+++ b/convex/argumentsValidation.test.ts
@@ -1,6 +1,9 @@
+import { anyApi } from "convex/server";
+import { v } from "convex/values";
 import { expect, test } from "vitest";
 import { convexTest } from "../index";
 import { api } from "./_generated/api";
+import { action, mutation, query } from "./_generated/server";
 import schema from "./schema";
 import counterSchema from "./counter/component/schema";
 
@@ -70,6 +73,88 @@ test("component mutation arguments validation", async () => {
       a: Number.POSITIVE_INFINITY,
     }),
   ).toEqual(Number.POSITIVE_INFINITY);
+});
+
+// The real backend only accepts an object or `v.any()` as the args validator,
+// and rejects anything else at push time. These functions can't live in
+// `convex/` because they'd break `npx convex dev`, so they're defined inline.
+function testWithBadArgsValidators() {
+  return convexTest({
+    schema,
+    modules: {
+      "./_generated/server.ts": () => Promise.resolve({}),
+      "./badArgs.ts": () =>
+        Promise.resolve({
+          unionQuery: query({
+            args: v.union(
+              v.object({ a: v.number() }),
+              v.object({ b: v.number() }),
+            ),
+            /* v8 ignore next */
+            handler: () => "ok",
+          }),
+          unionMutation: mutation({
+            args: v.union(
+              v.object({ a: v.number() }),
+              v.object({ b: v.number() }),
+            ),
+            /* v8 ignore next */
+            handler: () => "ok",
+          }),
+          unionAction: action({
+            args: v.union(
+              v.object({ a: v.number() }),
+              v.object({ b: v.number() }),
+            ),
+            /* v8 ignore next */
+            handler: () => "ok",
+          }),
+          recordQuery: query({
+            args: v.record(v.string(), v.number()),
+            /* v8 ignore next */
+            handler: () => "ok",
+          }),
+        }),
+    },
+  });
+}
+
+test("args validator must be an object or any", async () => {
+  const t = testWithBadArgsValidators();
+  const message =
+    "Invalid JSON returned from badArgs.js:unionQuery.exportArgs(): " +
+    "Args validator must be an object or any";
+  await expect(
+    t.query(anyApi.badArgs.unionQuery, { a: 1 }),
+  ).rejects.toThrowError(message);
+  await expect(
+    t.mutation(anyApi.badArgs.unionMutation, { a: 1 }),
+  ).rejects.toThrowError(/Args validator must be an object or any/);
+  await expect(
+    t.action(anyApi.badArgs.unionAction, { a: 1 }),
+  ).rejects.toThrowError(/Args validator must be an object or any/);
+  await expect(
+    t.query(anyApi.badArgs.recordQuery, { a: 1 }),
+  ).rejects.toThrowError(/Args validator must be an object or any/);
+});
+
+test("object and any args validators are allowed", async () => {
+  const t = convexTest(schema);
+  expect(
+    await t.query(api.argumentsValidation.queryWithObjectValidatorArgs, {
+      a: 1,
+    }),
+  ).toEqual("ok");
+  await expect(
+    t.query(api.argumentsValidation.queryWithObjectValidatorArgs, {
+      a: "bad" as any,
+    }),
+  ).rejects.toThrowError(/Validator error/);
+  expect(
+    await t.query(api.argumentsValidation.queryWithAnyArgs, {
+      anything: true,
+    } as any),
+  ).toEqual("ok");
 });
 
 test("query with union arg", async () => {

--- a/convex/argumentsValidation.ts
+++ b/convex/argumentsValidation.ts
@@ -57,6 +57,20 @@ export const componentMutationWithNumberArg = mutation({
   },
 });
 
+export const queryWithObjectValidatorArgs = query({
+  args: v.object({ a: v.number() }),
+  handler: () => {
+    return "ok";
+  },
+});
+
+export const queryWithAnyArgs = query({
+  args: v.any(),
+  handler: () => {
+    return "ok";
+  },
+});
+
 export const queryWithUnionArg = query({
   args: {
     a: v.union(v.number(), v.string()),

--- a/index.ts
+++ b/index.ts
@@ -3291,7 +3291,15 @@ async function resolveFunction<T extends RegisteredFunctionKind>(
       // eslint-disable-next-line @typescript-eslint/only-throw-error
       throw type satisfies never;
   }
-  const args = JSON.parse(func.exportArgs());
+  const args = JSON.parse(func.exportArgs()) as ValidatorJSON;
+  // The real backend rejects these functions at push time, so surface the same
+  // error as soon as the function is resolved.
+  if (args.type !== "object" && args.type !== "any") {
+    throw new Error(
+      `Invalid JSON returned from ${modulePath}.js:${exportName}.exportArgs(): ` +
+        `Args validator must be an object or any`,
+    );
+  }
   const returns = JSON.parse(func.exportReturns());
 
   return { func, functionPath, handler, returns, args };


### PR DESCRIPTION
Convex rejects top-level function argument validators other than an object or `v.any()`, but convex-test previously accepted them. Reject unsupported validators when resolving a query, mutation, or action, using the backend's error message. Modules load lazily, so this validation runs when a function is called.