### PR TITLE
feat: support snapshot timestamps in queries and mutations

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -18,6 +18,7 @@ import type * as convexError from "../convexError.js";
 import type * as explicitTableNames from "../explicitTableNames.js";
 import type * as getDeploymentMetadata from "../getDeploymentMetadata.js";
 import type * as getFunctionMetadata from "../getFunctionMetadata.js";
+import type * as getSnapshotTs from "../getSnapshotTs.js";
 import type * as helpers from "../helpers.js";
 import type * as http from "../http.js";
 import type * as messages from "../messages.js";
@@ -48,6 +49,7 @@ declare const fullApi: ApiFromModules<{
   explicitTableNames: typeof explicitTableNames;
   getDeploymentMetadata: typeof getDeploymentMetadata;
   getFunctionMetadata: typeof getFunctionMetadata;
+  getSnapshotTs: typeof getSnapshotTs;
   helpers: typeof helpers;
   http: typeof http;
   messages: typeof messages;

--- a/convex/commitTs.test.ts
+++ b/convex/commitTs.test.ts
@@ -159,7 +159,7 @@ test("staged rows sort after committed ones", async () => {
   });
 });
 
-test("a rolled back mutation writes nothing and still advances the last commit timestamp", async () => {
+test("a rolled back mutation writes nothing, and later commits still advance", async () => {
   const t = convexTest(schema);
   const before = await t.mutation(api.commitTs.returnCommitTs, {});
   await expect(t.mutation(api.commitTs.insertThenThrow, {})).rejects.toThrow(

--- a/convex/counter/component/_generated/component.ts
+++ b/convex/counter/component/_generated/component.ts
@@ -96,5 +96,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         any,
         Name
       >;
+      snapshot: FunctionReference<"query", "internal", {}, bigint, Name>;
     };
   };

--- a/convex/counter/component/public.ts
+++ b/convex/counter/component/public.ts
@@ -1,6 +1,13 @@
 import { v } from "convex/values";
 import { action, mutation, query } from "./_generated/server";
 import { api } from "./_generated/api";
+import { getSnapshotTs } from "../../getSnapshotTs";
+
+export const snapshot = query({
+  args: {},
+  returns: v.int64(),
+  handler: () => getSnapshotTs(),
+});
 
 export const add = mutation({
   args: {

--- a/convex/getSnapshotTs.test.ts
+++ b/convex/getSnapshotTs.test.ts
@@ -1,0 +1,272 @@
+/// <reference types="vite/client" />
+
+import { afterEach, expect, test, vi } from "vitest";
+import { convexTest } from "../index";
+import { api, components } from "./_generated/api";
+import { QueryCtx } from "./_generated/server";
+import { getSnapshotTs } from "./getSnapshotTs";
+import schema from "./schema";
+import counterSchema from "./counter/component/schema";
+
+const counterModules = import.meta.glob("./counter/component/**/*.ts");
+const now = 1_750_000_000_000;
+
+function expectBigint(value: unknown): bigint {
+  if (typeof value !== "bigint") {
+    expect.fail(`expected a bigint, got ${typeof value}`);
+  }
+  return value;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+test.each(["query", "mutation", "run"] as const)(
+  "%s returns a synchronous bigint snapshot in Unix nanoseconds",
+  async (type) => {
+    vi.useFakeTimers({ now });
+    const t = convexTest(schema);
+    const commitTs = await t.mutation(async (ctx) => ctx.db.vars.commitTs);
+    const handler = async () => {
+      const ts = getSnapshotTs();
+      expect(typeof ts).toBe("bigint");
+      return ts;
+    };
+    const snapshotTs = await (type === "query"
+      ? t.query(handler)
+      : type === "mutation"
+        ? t.mutation(handler)
+        : t.run(handler));
+    expect(snapshotTs).toBe(BigInt(now) * 1_000_000n);
+    expect(snapshotTs).toBe(commitTs);
+  },
+);
+
+test.each(["query", "mutation"] as const)(
+  "%s captures its snapshot at transaction start and keeps it stable",
+  async (type) => {
+    vi.useFakeTimers({ now });
+    const t = convexTest(schema);
+    const commitTs = await t.mutation(async (ctx) => ctx.db.vars.commitTs);
+    vi.setSystemTime(now + 500);
+    const handler = async (ctx: QueryCtx) => {
+      // Advancing time before the first syscall must not change the snapshot.
+      vi.setSystemTime(now + 1000);
+      const snapshotTs = getSnapshotTs();
+      expect(snapshotTs).toBe(commitTs);
+      await ctx.db.query("commitTs").first();
+      vi.setSystemTime(now + 2000);
+      expect(getSnapshotTs()).toBe(snapshotTs);
+    };
+    if (type === "query") {
+      await t.query(handler);
+    } else {
+      await t.mutation(handler);
+    }
+  },
+);
+
+test("an empty database starts at timestamp zero", async () => {
+  const t = convexTest(schema);
+  expect(await t.query(api.getSnapshotTs.snapshotQuery)).toBe(0n);
+});
+
+test("the commit timestamp is assigned at the end of the transaction", async () => {
+  vi.useFakeTimers({ now });
+  const t = convexTest(schema);
+  const previousCommit = await t.mutation(async (ctx) => ctx.db.vars.commitTs);
+  const result = await t.mutation(async (ctx) => {
+    const snapshotTs = getSnapshotTs();
+    vi.setSystemTime(now + 1000);
+    return { snapshotTs, commitTs: ctx.db.vars.commitTs };
+  });
+  expect(result.snapshotTs).toBe(previousCommit);
+  expect(result.commitTs).toBe(BigInt(now + 1000) * 1_000_000n);
+  expect(await t.query(api.getSnapshotTs.snapshotQuery)).toBe(result.commitTs);
+});
+
+test.each([0, -1000])(
+  "snapshots separate previous and future commits with clock delta %i ms",
+  async (clockDelta) => {
+    vi.useFakeTimers({ now });
+    const t = convexTest(schema);
+    let previousSnapshot = await t.query(api.getSnapshotTs.snapshotQuery);
+    let previousCommit = 0n;
+    for (let i = 0; i < 3; i++) {
+      vi.setSystemTime(now + i * clockDelta);
+      const { id, snapshotTs, commitTs } = await t.mutation(
+        api.getSnapshotTs.snapshotMutation,
+      );
+      expect(typeof commitTs).toBe("bigint");
+      expect(snapshotTs).toBe(previousCommit);
+      expect(commitTs).toBeGreaterThan(snapshotTs);
+      expect(commitTs).toBeGreaterThan(previousSnapshot);
+      expect(commitTs).toBeGreaterThan(previousCommit);
+      const doc = await t.query(api.commitTs.getDoc, { id });
+      expect(doc!.commitTs).toBe(commitTs);
+      // Both timestamps use nanoseconds, including the resolved placeholder.
+      expect(commitTs).toBeGreaterThanOrEqual(BigInt(now) * 1_000_000n);
+      expect(commitTs).toBeLessThan(BigInt(now + 1) * 1_000_000n);
+      previousSnapshot = await t.query(api.getSnapshotTs.snapshotQuery);
+      expect(previousSnapshot).toBe(commitTs);
+      previousCommit = expectBigint(commitTs);
+    }
+  },
+);
+
+test("queries keep the latest commit timestamp even as the clock moves", async () => {
+  vi.useFakeTimers({ now });
+  const t = convexTest(schema);
+  const commitTs = expectBigint(
+    await t.mutation(async (ctx) => ctx.db.vars.commitTs),
+  );
+  for (const clockDelta of [0, 1000, -1000]) {
+    vi.setSystemTime(now + clockDelta);
+    expect(await t.query(api.getSnapshotTs.snapshotQuery)).toBe(commitTs);
+  }
+  const result = await t.mutation(api.getSnapshotTs.snapshotMutation);
+  expect(result.snapshotTs).toBe(commitTs);
+  expect(result.commitTs).toBe(commitTs + 1n);
+});
+
+test.each(["query", "mutation"] as const)(
+  "a failed %s leaves the latest commit timestamp unchanged and releases its snapshot",
+  async (type) => {
+    vi.useFakeTimers({ now });
+    const t = convexTest(schema);
+    const commitTs = expectBigint(
+      await t.mutation(async (ctx) => ctx.db.vars.commitTs),
+    );
+    vi.setSystemTime(now + 1000);
+    let snapshotTs = 0n;
+    const handler = async () => {
+      snapshotTs = getSnapshotTs();
+      throw new Error("rollback");
+    };
+    await expect(
+      type === "query" ? t.query(handler) : t.mutation(handler),
+    ).rejects.toThrow("rollback");
+    expect(snapshotTs).toBe(commitTs);
+    expect(await t.query(api.getSnapshotTs.snapshotQuery)).toBe(commitTs);
+    await expect(t.action(async () => getSnapshotTs())).rejects.toThrow(
+      "getSnapshotTs() can only be called from a query or mutation",
+    );
+    vi.setSystemTime(now - 1000);
+    const result = await t.mutation(api.getSnapshotTs.snapshotMutation);
+    expect(result.snapshotTs).toBe(commitTs);
+    expect(result.commitTs).toBe(commitTs + 1n);
+  },
+);
+
+test("nested queries, mutations, and stale snapshot queries share the outer snapshot", async () => {
+  vi.useFakeTimers({ now });
+  const t = convexTest(schema);
+  const result = await t.mutation(async (ctx) => {
+    const snapshotTs = getSnapshotTs();
+    vi.setSystemTime(now + 1000);
+    expect(await ctx.runQuery(api.getSnapshotTs.snapshotQuery)).toBe(
+      snapshotTs,
+    );
+    const nested = await ctx.runMutation(api.getSnapshotTs.snapshotMutation);
+    expect(nested.snapshotTs).toBe(snapshotTs);
+    expect(
+      await ctx.runQuery(
+        api.getSnapshotTs.snapshotQuery,
+        {},
+        { useStaleSnapshot: true },
+      ),
+    ).toBe(snapshotTs);
+    await expect(ctx.runMutation(api.commitTs.insertThenThrow)).rejects.toThrow(
+      "rollback",
+    );
+    expect(getSnapshotTs()).toBe(snapshotTs);
+    return { snapshotTs, commitTs: ctx.db.vars.commitTs, nested };
+  });
+  expect(result.nested.commitTs).toBe(result.commitTs);
+  expect(result.commitTs).toBeGreaterThan(result.snapshotTs);
+  expect(
+    (await t.query(api.commitTs.getDoc, { id: result.nested.id }))!.commitTs,
+  ).toBe(result.commitTs);
+});
+
+test("nested queries share their parent query's snapshot", async () => {
+  vi.useFakeTimers({ now });
+  const t = convexTest(schema);
+  await t.query(async (ctx) => {
+    const snapshotTs = getSnapshotTs();
+    vi.setSystemTime(now + 1000);
+    expect(await ctx.runQuery(api.getSnapshotTs.snapshotQuery)).toBe(
+      snapshotTs,
+    );
+    expect(getSnapshotTs()).toBe(snapshotTs);
+  });
+});
+
+test("component calls share the snapshot and commit clock", async () => {
+  vi.useFakeTimers({ now });
+  const t = convexTest(schema);
+  t.registerComponent("counter", counterSchema, counterModules);
+  const result = await t.mutation(async (ctx) => {
+    const snapshotTs = getSnapshotTs();
+    vi.setSystemTime(now + 1000);
+    expect(await ctx.runQuery(components.counter.public.snapshot)).toBe(
+      snapshotTs,
+    );
+    await ctx.runMutation(components.counter.public.addWithCommitTs, {
+      name: "snapshot",
+    });
+    expect(getSnapshotTs()).toBe(snapshotTs);
+    return { snapshotTs, commitTs: ctx.db.vars.commitTs };
+  });
+  expect(
+    await t.query(components.counter.public.getCommitTs, { name: "snapshot" }),
+  ).toBe(result.commitTs);
+  expect(result.commitTs).toBeGreaterThan(result.snapshotTs);
+  expect(await t.query(components.counter.public.snapshot)).toBe(
+    result.commitTs,
+  );
+});
+
+test("a queued query takes its snapshot after the preceding mutation commits", async () => {
+  vi.useFakeTimers({ now });
+  const t = convexTest(schema);
+  let started!: () => void;
+  let release!: () => void;
+  const mutationStarted = new Promise<void>((resolve) => {
+    started = resolve;
+  });
+  const mutationReleased = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const mutation = t.mutation(async (ctx) => {
+    started();
+    await mutationReleased;
+    return ctx.db.vars.commitTs;
+  });
+  await mutationStarted;
+  const query = t.query(async () => getSnapshotTs());
+  release();
+  const [commitTs, snapshotTs] = await Promise.all([mutation, query]);
+  expect(snapshotTs).toBe(commitTs);
+});
+
+test("independent test instances have independent timestamp clocks", async () => {
+  vi.useFakeTimers({ now });
+  const first = convexTest(schema);
+  const firstCommit = await first.mutation(async (ctx) => ctx.db.vars.commitTs);
+  const firstSnapshot = await first.query(api.getSnapshotTs.snapshotQuery);
+  expect(firstSnapshot).toBe(firstCommit);
+  vi.setSystemTime(now - 1000);
+  const second = convexTest(schema);
+  expect(await second.query(api.getSnapshotTs.snapshotQuery)).toBe(0n);
+  const secondCommit = await second.mutation(
+    async (ctx) => ctx.db.vars.commitTs,
+  );
+  const secondSnapshot = await second.query(api.getSnapshotTs.snapshotQuery);
+  expect(secondSnapshot).toBe(secondCommit);
+  expect(secondSnapshot).toBe(BigInt(now - 1000) * 1_000_000n);
+  expect(await first.query(api.getSnapshotTs.snapshotQuery)).toBe(
+    firstSnapshot,
+  );
+});

--- a/convex/getSnapshotTs.ts
+++ b/convex/getSnapshotTs.ts
@@ -1,0 +1,33 @@
+import { jsonToConvex, v } from "convex/values";
+import { mutation, query } from "./_generated/server";
+
+// TODO: replace with ctx.meta.getSnapshotTs() once available in the SDK.
+export function getSnapshotTs(): bigint {
+  const syscalls = (globalThis as any).Convex;
+  const syscallJSON = JSON.parse(
+    syscalls.syscall("1.0/getSnapshotTs", JSON.stringify({})),
+  );
+  return jsonToConvex(syscallJSON) as bigint;
+}
+
+export const snapshotQuery = query({
+  args: {},
+  returns: v.int64(),
+  handler: () => getSnapshotTs(),
+});
+
+export const snapshotMutation = mutation({
+  args: {},
+  returns: v.object({
+    id: v.id("commitTs"),
+    snapshotTs: v.int64(),
+    commitTs: v.commitTs(),
+  }),
+  handler: async (ctx) => {
+    const snapshotTs = getSnapshotTs();
+    const id = await ctx.db.insert("commitTs", {
+      commitTs: ctx.db.vars.commitTs,
+    });
+    return { id, snapshotTs, commitTs: ctx.db.vars.commitTs };
+  },
+});

--- a/index.ts
+++ b/index.ts
@@ -1386,6 +1386,11 @@ function syscallImpl() {
     const args = JSON.parse(jsonArgs);
     const db = getDb();
     switch (op) {
+      case "1.0/getSnapshotTs": {
+        return JSON.stringify(
+          convexToJson(getTransactionManager().getSnapshotTs()),
+        );
+      }
       case "1.0/queryStream": {
         const { query } = args;
         const tracker = getTransactionManager().getMetricsTracker();
@@ -2267,7 +2272,8 @@ class TransactionManager {
   // `startTransaction` / `commit` / `rollback` in lockstep with the databases'.
   private _metricsTracker: TransactionMetricsTracker | null = null;
   private _limitsConfig: Partial<TransactionMetrics> | boolean;
-  // The last commit timestamp handed out. Strictly increases across transactions.
+  // The latest committed transaction's timestamp, in Unix nanoseconds.
+  // Zero represents the initial empty database, before any commits.
   private _lastCommitTs: bigint = 0n;
 
   constructor(limitsConfig: Partial<TransactionMetrics> | boolean = false) {
@@ -2312,13 +2318,25 @@ class TransactionManager {
     return this._metricsTracker;
   }
 
+  getSnapshotTs(): bigint {
+    if (!this.isInTransaction()) {
+      throw new Error(
+        "getSnapshotTs() can only be called from a query or mutation.",
+      );
+    }
+    // Top-level transactions are serialized and nested commits don't advance
+    // _lastCommitTs, so it remains the latest commit known at transaction start.
+    return this._lastCommitTs;
+  }
+
   // Returns the transaction's commit timestamp, or null for a nested commit,
   // whose writes stay pending until the outermost transaction commits.
   commit(isNested: boolean): bigint | null {
     let commitTs: bigint | null = null;
     if (!isNested) {
       const nowNanos = BigInt(Date.now()) * 1_000_000n;
-      // Bump by one if the clock has not advanced since the last commit.
+      // Assign a new timestamp only when committing the outermost transaction.
+      // Bump by one if the clock is frozen or has moved backwards.
       commitTs =
         nowNanos > this._lastCommitTs ? nowNanos : this._lastCommitTs + 1n;
       this._lastCommitTs = commitTs;


### PR DESCRIPTION
Adds support for the upcoming `ctx.meta.getSnapshotTs()` through the synchronous `1.0/getSnapshotTs` syscall. It returns the latest known commit timestamp at transaction start as a bigint in Unix nanoseconds, using the existing `db.vars.commitTs` support. An empty database starts at `0n`.

Top-level transactions are serialized, so returning the latest commit timestamp keeps snapshots stable across nested queries, mutations, and component calls. Only the outermost commit advances the timestamp; queries and rollbacks leave it unchanged.

Adds 17 regression tests covering exact equality with the preceding commit, commit-time assignment, nested and stale snapshot queries, components, rollback, frozen/backward clocks, queued transactions, and independent test instances. Tests invoke the syscall directly until the SDK method is released.

Validation:

- All 274 tests pass (`npm run test:once`).
- ESLint and source formatting pass. Prettier excludes `.context`, whose local review attachment fails the default formatting check.
- Convex typechecking passes (`npx tsc --noEmit -p convex/tsconfig.json`).
- Compilation and packaging pass (`npm --ignore-scripts run build`); the prebuild checks above were run separately.
