### PR TITLE
feat: add typed in-memory test applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,88 @@ the Convex backend in TypeScript, for use in automated tests of Convex
 functions.
 
 Check out the Convex testing docs: https://docs.convex.dev/testing/convex-test
+
+// TODO: move this to official docs
+## Define a test application
+
+Use `defineTestApp` to define a small application for tests, such as a host
+application for a component. It provides schema-bound function builders, typed
+function references, and fresh `convexTest` instances without generated files or
+an `import.meta.glob` for the application.
+
+```ts
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+import { defineTestApp } from "convex-test";
+import { expect, test } from "vitest";
+
+const schema = defineSchema({
+  events: defineTable({ key: v.string() }).index("key", ["key"]),
+});
+const app = defineTestApp({ schema });
+
+const { api, internal, createTest } = app.defineModules({
+  test: {
+    bar: app.mutation({
+      args: { key: v.string() },
+      returns: v.id("events"),
+      handler: async (ctx, args) => await ctx.db.insert("events", args),
+    }),
+    record: app.internalAction({
+      args: { key: v.string() },
+      returns: v.null(),
+      handler: async (ctx, args): Promise<null> => {
+        await ctx.runMutation(api.test.bar, args);
+        return null;
+      },
+    }),
+  },
+});
+
+test("records an event", async () => {
+  const t = createTest();
+  await t.action(internal.test.record, { key: "example" });
+  const event = await t.query(async (ctx) =>
+    ctx.db
+      .query("events")
+      .withIndex("key", (q) => q.eq("key", "example"))
+      .unique(),
+  );
+  expect(event?.key).toBe("example");
+});
+```
+
+The builders are `query`, `mutation`, `action`, `internalQuery`,
+`internalMutation`, and `internalAction`. They use the same arguments, return
+validators, and handlers as the corresponding generated Convex builders.
+Handlers that reference the API being defined may need an explicit return type
+annotation, as `record` does above, to break TypeScript inference cycles.
+
+Module keys are paths without a leading `./` or file extension. For example,
+`"test/callbacks"` produces references under `api.test.callbacks` or
+`internal.test.callbacks`. Values are objects of module exports, including
+already-registered functions. Public functions appear in `api`; internal
+functions appear in `internal`. Other exports are omitted from the API types.
+The references work with nested function calls, scheduling, and
+`createFunctionHandle`, using the existing `convex-test` execution and validation
+behavior.
+
+Call `createTest()` inside each test for fresh database, scheduler, and component
+registration state. It returns a normal `TestConvex<typeof schema>` that supports
+component packages' existing default testing helpers:
+
+```ts
+import workpoolTest from "@convex-dev/workpool/test";
+
+const t = createTest();
+workpoolTest.register(t);
+// Or register under a custom name:
+workpoolTest.register(t, "anotherWorkpool");
+```
+
+You can also use `t.registerComponent(name, componentSchema, componentModules)`
+directly. Component registration remains explicit; `defineTestApp` does not load
+`convex.config.ts`. `withIdentity`, `run`, and the other test methods work as
+usual. To enable transaction limits, pass the same settings supported by
+`convexTest`, for example `createTest({ transactionLimits: true })`.
+>>>>>>> e36897f (docs: document test application setup)

--- a/convex/counter/component/callbacks.ts
+++ b/convex/counter/component/callbacks.ts
@@ -1,0 +1,18 @@
+import type { FunctionHandle } from "convex/server";
+import { v } from "convex/values";
+import { mutation } from "./_generated/server";
+
+export const invoke = mutation({
+  args: { handle: v.string(), key: v.string(), fail: v.optional(v.boolean()) },
+  returns: v.null(),
+  handler: async (ctx, { handle, ...args }) => {
+    return await ctx.runMutation(
+      handle as FunctionHandle<
+        "mutation",
+        { key: string; fail?: boolean },
+        null
+      >,
+      args,
+    );
+  },
+});

--- a/convex/counter/test.ts
+++ b/convex/counter/test.ts
@@ -1,0 +1,14 @@
+import type { GenericSchema, SchemaDefinition } from "convex/server";
+import type { TestConvex } from "../../index";
+import schema from "./component/schema";
+
+const modules = import.meta.glob("./component/**/*.ts");
+
+// Match the testing entry point convention used by published components.
+export function register<
+  Schema extends SchemaDefinition<GenericSchema, boolean>,
+>(t: TestConvex<Schema>, name = "counter") {
+  t.registerComponent(name, schema, modules);
+}
+
+export default { register, schema, modules };

--- a/convex/defineTestApp.test.ts
+++ b/convex/defineTestApp.test.ts
@@ -1,0 +1,322 @@
+import { afterEach, expect, expectTypeOf, test, vi } from "vitest";
+import {
+  type ApiFromModules,
+  type DataModelFromSchemaDefinition,
+  type GenericMutationCtx,
+  componentsGeneric,
+  createFunctionHandle,
+  defineSchema,
+  defineTable,
+  getFunctionName,
+  makeFunctionReference,
+} from "convex/server";
+import { v } from "convex/values";
+import { defineTestApp, type TestConvex } from "../index";
+import { components } from "./_generated/api";
+import counterTest from "./counter/test";
+import type * as counterCallbacks from "./counter/component/callbacks";
+
+const schema = defineSchema({
+  events: defineTable({ key: v.string() }).index("key", ["key"]),
+});
+const app = defineTestApp({ schema });
+const callback = vi.fn(
+  async (
+    ctx: GenericMutationCtx<DataModelFromSchemaDefinition<typeof schema>>,
+    { key, fail }: { key: string; fail?: boolean },
+  ) => {
+    await ctx.db.insert("events", { key });
+    if (fail) throw new Error("callback failed");
+    return null;
+  },
+);
+
+const { api, internal, createTest } = app.defineModules({
+  test: {
+    bar: app.mutation({
+      args: { key: v.string() },
+      returns: v.id("events"),
+      handler: async (ctx, args) => await ctx.db.insert("events", args),
+    }),
+    list: app.query({
+      args: { key: v.string() },
+      returns: v.array(v.string()),
+      handler: async (ctx, { key }) => {
+        const events = await ctx.db
+          .query("events")
+          .withIndex("key", (q) => q.eq("key", key))
+          .collect();
+        return events.map((event) => event.key);
+      },
+    }),
+    run: app.action({
+      args: { key: v.string() },
+      returns: v.number(),
+      handler: async (ctx, args): Promise<number> => {
+        return await ctx.runAction(internal.test.callbacks.run, args);
+      },
+    }),
+    identity: app.query({
+      args: {},
+      returns: v.union(v.string(), v.null()),
+      handler: async (ctx) => (await ctx.auth.getUserIdentity())?.name ?? null,
+    }),
+  },
+  "test/callbacks": {
+    complete: app.internalMutation({
+      args: { key: v.string(), fail: v.optional(v.boolean()) },
+      returns: v.null(),
+      handler: callback,
+    }),
+    count: app.internalQuery({
+      args: { key: v.string() },
+      returns: v.number(),
+      handler: async (ctx, args): Promise<number> => {
+        return (await ctx.runQuery(api.test.list, args)).length;
+      },
+    }),
+    run: app.internalAction({
+      args: { key: v.string() },
+      returns: v.number(),
+      handler: async (ctx, args): Promise<number> => {
+        await ctx.runMutation(internal.test.callbacks.complete, args);
+        return await ctx.runQuery(internal.test.callbacks.count, args);
+      },
+    }),
+    schedule: app.internalMutation({
+      args: { key: v.string() },
+      returns: v.null(),
+      handler: async (ctx, args): Promise<null> => {
+        await ctx.scheduler.runAfter(0, internal.test.callbacks.run, args);
+        return null;
+      },
+    }),
+  },
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  callback.mockClear();
+});
+
+test("defines typed functions without generated modules", async () => {
+  const t = createTest();
+  expectTypeOf(t).toEqualTypeOf<TestConvex<typeof schema>>();
+  const id = await t.mutation(api.test.bar, { key: "hello" });
+  const event = await t.run(async (ctx) => await ctx.db.get(id));
+  expect(event).toMatchObject({ key: "hello" });
+  expectTypeOf(event!.key).toEqualTypeOf<string>();
+  expect(await t.query(api.test.list, { key: "hello" })).toEqual(["hello"]);
+  expect(getFunctionName(api.test.bar)).toBe("test:bar");
+  expect(getFunctionName(internal.test.callbacks.complete)).toBe(
+    "test/callbacks:complete",
+  );
+});
+
+test("public and internal functions can call sibling modules", async () => {
+  const t = createTest();
+  const result = await t.action(api.test.run, { key: "work" });
+  expectTypeOf(result).toEqualTypeOf<number>();
+  expect(result).toBe(1);
+  expect(callback).toHaveBeenCalledTimes(1);
+  expect(await t.query(internal.test.callbacks.count, { key: "work" })).toBe(1);
+});
+
+test("preserves argument validation, schema validation, and rollback", async () => {
+  const t = createTest();
+  await expect(
+    t.mutation(internal.test.callbacks.complete, { key: 123 as any }),
+  ).rejects.toThrow("Validator error");
+  expect(callback).not.toHaveBeenCalled();
+  await expect(
+    t.run(async (ctx) => await ctx.db.insert("events", { key: 123 as any })),
+  ).rejects.toThrow("Validator error");
+  await expect(
+    t.mutation(internal.test.callbacks.complete, { key: "failed", fail: true }),
+  ).rejects.toThrow("callback failed");
+  expect(callback).toHaveBeenCalledTimes(1);
+  expect(await t.query(api.test.list, { key: "failed" })).toEqual([]);
+});
+
+test("preserves return validation", async () => {
+  const fixture = app.defineModules({
+    invalid: {
+      result: app.query({
+        args: {},
+        returns: v.number(),
+        handler: () => "wrong" as any,
+      }),
+    },
+  });
+  await expect(
+    fixture.createTest().query(fixture.api.invalid.result),
+  ).rejects.toThrow("Return value validation failed");
+});
+
+test("instances and identities retain their own state", async () => {
+  const first = createTest();
+  const second = createTest();
+  const asAlice = first.withIdentity({ name: "Alice" });
+  await asAlice.mutation(api.test.bar, { key: "first" });
+  await second.mutation(api.test.bar, { key: "second" });
+  expect(await first.query(api.test.list, { key: "first" })).toEqual(["first"]);
+  expect(await second.query(api.test.list, { key: "first" })).toEqual([]);
+  expect(await first.query(api.test.list, { key: "second" })).toEqual([]);
+  expect(await second.query(api.test.list, { key: "second" })).toEqual([
+    "second",
+  ]);
+  expect(await asAlice.query(api.test.identity)).toBe("Alice");
+  expect(await first.query(api.test.identity)).toBeNull();
+  expect(await second.query(api.test.identity)).toBeNull();
+});
+
+test("schedules named functions and their nested calls", async () => {
+  vi.useFakeTimers();
+  const t = createTest();
+  await t.mutation(internal.test.callbacks.schedule, { key: "scheduled" });
+  await t.finishAllScheduledFunctions(vi.runAllTimers);
+  expect(callback).toHaveBeenCalledTimes(1);
+  expect(await t.query(api.test.list, { key: "scheduled" })).toEqual([
+    "scheduled",
+  ]);
+});
+
+test("accepts a component's default testing helper and custom registration name", async () => {
+  const t = createTest();
+  counterTest.register(t);
+  counterTest.register(t, "counter2");
+  await t.action(async (ctx) => {
+    await ctx.runMutation(components.counter.public.add, {
+      name: "beans",
+      count: 3,
+    });
+    await ctx.runMutation(components.counter2.public.add, {
+      name: "beans",
+      count: 5,
+    });
+  });
+  expect(
+    await t.query(components.counter.public.count, { name: "beans" }),
+  ).toBe(3);
+  expect(
+    await t.query(components.counter2.public.count, { name: "beans" }),
+  ).toBe(5);
+  await t.mutation(api.test.bar, { key: "application" });
+  expect(await t.query(api.test.list, { key: "application" })).toEqual([
+    "application",
+  ]);
+
+  const other = createTest();
+  await expect(
+    other.query(components.counter.public.count, { name: "beans" }),
+  ).rejects.toThrow('Component "counter" is not registered');
+  counterTest.register(other);
+  expect(
+    await other.query(components.counter.public.count, { name: "beans" }),
+  ).toBe(0);
+});
+
+test("components invoke application callbacks through function handles", async () => {
+  const t = createTest();
+  counterTest.register(t);
+  const counter = (
+    componentsGeneric() as unknown as {
+      counter: ApiFromModules<{ callbacks: typeof counterCallbacks }>;
+    }
+  ).counter;
+  const handle = await t.run(async () => {
+    return await createFunctionHandle(internal.test.callbacks.complete);
+  });
+  await t.mutation(counter.callbacks.invoke, { handle, key: "callback" });
+  expect(callback).toHaveBeenCalledTimes(1);
+  expect(await t.query(api.test.list, { key: "callback" })).toEqual([
+    "callback",
+  ]);
+  await expect(
+    t.mutation(counter.callbacks.invoke, { handle, key: "failed", fail: true }),
+  ).rejects.toThrow("callback failed");
+  expect(await t.query(api.test.list, { key: "failed" })).toEqual([]);
+});
+
+test("supports default exports and excludes ordinary exports from API types", async () => {
+  const fixture = app.defineModules({
+    example: {
+      default: app.query({ args: {}, returns: v.number(), handler: () => 42 }),
+      helper: () => "ordinary export",
+    },
+  });
+  expect(await fixture.createTest().query(fixture.api.example.default)).toBe(
+    42,
+  );
+  // @ts-expect-error Ordinary exports are not function references.
+  void fixture.api.example.helper;
+});
+
+test("empty definitions support inline calls and report missing modules", async () => {
+  const t = app.defineModules({}).createTest();
+  await t.mutation(async (ctx) => {
+    await ctx.db.insert("events", { key: "inline" });
+  });
+  expect(
+    await t.query(
+      async (ctx) => (await ctx.db.query("events").collect()).length,
+    ),
+  ).toBe(1);
+  await expect(
+    t.query(makeFunctionReference<"query">("missing:query")),
+  ).rejects.toThrow('Could not find module for: "missing"');
+});
+
+test("forwards transaction limit options to the normal test runtime", async () => {
+  const t = createTest({ transactionLimits: { documentsWritten: 0 } });
+  await expect(t.mutation(api.test.bar, { key: "limited" })).rejects.toThrow(
+    "Wrote too many documents",
+  );
+  expect(await t.query(api.test.list, { key: "limited" })).toEqual([]);
+});
+
+test("rejects incorrect function references and schema usage at compile time", () => {
+  // This function is typechecked but deliberately never executed.
+  const checkTypes = async () => {
+    const t = createTest();
+    // @ts-expect-error Arguments are inferred from validators.
+    await t.mutation(api.test.bar, { key: 123 });
+    // @ts-expect-error Required arguments cannot be omitted.
+    await t.mutation(api.test.bar);
+    // @ts-expect-error Mutations cannot be called as queries.
+    await t.query(api.test.bar, { key: "wrong kind" });
+    // @ts-expect-error Internal functions are excluded from the public API.
+    void api.test.callbacks.complete;
+    // @ts-expect-error Public functions are excluded from the internal API.
+    void internal.test.bar;
+    // @ts-expect-error Unknown function names are rejected.
+    void api.test.missing;
+    // @ts-expect-error Function return types are preserved.
+    const wrong: string = await t.action(api.test.run, { key: "wrong return" });
+    void wrong;
+
+    app.mutation({
+      args: {},
+      returns: v.null(),
+      handler: async (ctx) => {
+        // @ts-expect-error Schema rejects unknown tables.
+        await ctx.db.insert("unknown", { key: "hello" });
+        // @ts-expect-error Schema rejects incorrect field types.
+        await ctx.db.insert("events", { key: 123 });
+        // @ts-expect-error Schema rejects unknown indexes.
+        await ctx.db.query("events").withIndex("missing").collect();
+        return null;
+      },
+    });
+    app.query({
+      args: {},
+      returns: v.null(),
+      handler: async (ctx) => {
+        // @ts-expect-error Query contexts cannot write.
+        await ctx.db.insert("events", { key: "hello" });
+        return null;
+      },
+    });
+  };
+  void checkTypes;
+});

--- a/index.ts
+++ b/index.ts
@@ -2,9 +2,12 @@
 
 import { AsyncLocalStorage } from "node:async_hooks";
 import {
+  ActionBuilder,
+  ApiFromModules,
   DataModelFromSchemaDefinition,
   DefaultFunctionArgs,
   DocumentByName,
+  FilterApi,
   FunctionReference,
   FunctionReturnType,
   GenericActionCtx,
@@ -14,8 +17,10 @@ import {
   GenericQueryCtx,
   GenericSchema,
   HttpRouter,
+  MutationBuilder,
   OptionalRestArgs,
   PublicHttpAction,
+  QueryBuilder,
   RegisteredAction,
   RegisteredMutation,
   RegisteredQuery,
@@ -23,8 +28,13 @@ import {
   SystemDataModel,
   UserIdentity,
   actionGeneric,
+  anyApi,
+  filterApi,
   getFunctionAddress,
   httpActionGeneric,
+  internalActionGeneric,
+  internalMutationGeneric,
+  internalQueryGeneric,
   makeFunctionReference,
   mutationGeneric,
   queryGeneric,
@@ -1914,6 +1924,127 @@ async function blobSha(blob: Blob) {
 export type TestConvex<SchemaDef extends SchemaDefinition<any, boolean>> =
   TestConvexRoot<DataModelFromSchemaDefinition<SchemaDef>>;
 
+/** Schema-bound function builders for an in-memory test application. */
+export type TestApp<SchemaDef extends SchemaDefinition<any, boolean>> = {
+  query: QueryBuilder<DataModelFromSchemaDefinition<SchemaDef>, "public">;
+  internalQuery: QueryBuilder<
+    DataModelFromSchemaDefinition<SchemaDef>,
+    "internal"
+  >;
+  mutation: MutationBuilder<DataModelFromSchemaDefinition<SchemaDef>, "public">;
+  internalMutation: MutationBuilder<
+    DataModelFromSchemaDefinition<SchemaDef>,
+    "internal"
+  >;
+  action: ActionBuilder<DataModelFromSchemaDefinition<SchemaDef>, "public">;
+  internalAction: ActionBuilder<
+    DataModelFromSchemaDefinition<SchemaDef>,
+    "internal"
+  >;
+  /**
+   * Define function modules by their paths, e.g. `test` or `test/callbacks`,
+   * without a leading `./` or file extension. Values are module exports,
+   * rather than the import functions returned by `import.meta.glob`.
+   *
+   * References have the same types and behavior as generated Convex APIs.
+   * Public functions appear in `api` and internal functions in `internal`.
+   * Handlers referencing this API may need explicit return type annotations
+   * to break TypeScript inference cycles.
+   */
+  defineModules<Modules extends Record<string, object>>(
+    this: void,
+    modules: Modules,
+  ): TestAppDefinition<SchemaDef, Modules>;
+};
+
+/** Typed function references and a factory for fresh test instances. */
+export type TestAppDefinition<
+  SchemaDef extends SchemaDefinition<any, boolean>,
+  Modules extends Record<string, object>,
+> = {
+  api: FilterApi<ApiFromModules<Modules>, FunctionReference<any, "public">>;
+  internal: FilterApi<
+    ApiFromModules<Modules>,
+    FunctionReference<any, "internal">
+  >;
+  /**
+   * Create fresh test state. Register components on the returned instance
+   * using their testing helpers or `t.registerComponent`.
+   * `transactionLimits` has the same meaning as in `convexTest`.
+   */
+  createTest(
+    this: void,
+    options?: { transactionLimits?: Partial<TransactionMetrics> | boolean },
+  ): TestConvex<SchemaDef>;
+};
+
+/**
+ * Define an in-memory test application without generated files.
+ *
+ * The returned function builders are typed against `schema`. Pass modules of
+ * registered functions to `defineModules` to get typed `api` and `internal`
+ * references and a `createTest` factory. Each call to `createTest` creates fresh
+ * test state and returns a normal {@link TestConvex}, which can be passed to
+ * component testing helpers such as `componentTest.register(t)`.
+ *
+ * @example
+ * const app = defineTestApp({ schema });
+ * const { api, createTest } = app.defineModules({
+ *   test: {
+ *     bar: app.mutation({
+ *       args: { text: v.string() },
+ *       returns: v.id("messages"),
+ *       handler: async (ctx, args) => ctx.db.insert("messages", args),
+ *     }),
+ *   },
+ * });
+ * const t = createTest();
+ * await t.mutation(api.test.bar, { text: "hello" });
+ */
+export function defineTestApp<
+  SchemaDef extends SchemaDefinition<any, boolean>,
+>({ schema }: { schema: SchemaDef }): TestApp<SchemaDef> {
+  return {
+    query: queryGeneric,
+    internalQuery: internalQueryGeneric,
+    mutation: mutationGeneric,
+    internalMutation: internalMutationGeneric,
+    action: actionGeneric,
+    internalAction: internalActionGeneric,
+
+    defineModules<Modules extends Record<string, object>>(modules: Modules) {
+      const moduleMap = new Map(Object.entries(modules));
+      const loadModule = async (path: string) => {
+        const module = moduleMap.get(path);
+        if (module === undefined) {
+          throw new Error(`Could not find module for: "${path}"`);
+        }
+        return module;
+      };
+      const fullApi = anyApi as unknown as ApiFromModules<Modules>;
+      return {
+        api: filterApi<typeof fullApi, FunctionReference<any, "public">>(
+          fullApi,
+        ),
+        internal: filterApi<typeof fullApi, FunctionReference<any, "internal">>(
+          fullApi,
+        ),
+        createTest(
+          options: {
+            transactionLimits?: Partial<TransactionMetrics> | boolean;
+          } = {},
+        ): TestConvex<SchemaDef> {
+          return createConvexTest(
+            schema,
+            loadModule,
+            options.transactionLimits ?? false,
+          );
+        },
+      };
+    },
+  };
+}
+
 export type TestConvexForDataModel<DataModel extends GenericDataModel> = {
   /**
    * Call a public or internal query, or run an inline query function.
@@ -2652,12 +2783,20 @@ export function convexTest<Schema extends GenericSchema>(
     limitsConfig = opts.transactionLimits ?? false;
   }
 
+  return createConvexTest(schema, moduleCache(modules), limitsConfig);
+}
+
+function createConvexTest<SchemaDef extends SchemaDefinition<any, boolean>>(
+  schema: SchemaDef | undefined,
+  modules: ComponentInfo["modules"],
+  limitsConfig: Partial<TransactionMetrics> | boolean,
+): TestConvex<SchemaDef> {
   const rootDb = new DatabaseFake(schema ?? null, ROOT_COMPONENT_PATH);
   const convexGlobal: ConvexGlobal = {
     components: {
       [ROOT_COMPONENT_PATH]: {
         db: rootDb,
-        modules: moduleCache(modules),
+        modules,
       },
     },
     transactionManager: new TransactionManager(limitsConfig),


### PR DESCRIPTION
Component tests currently need to hand-build schema-bound function builders, cast an API object, and provide a fake generated module to define a host application. Add `defineTestApp({ schema })` with typed builders and `defineModules`, which returns `api`, `internal`, and a `createTest()` factory without generated files.

Each factory call returns a normal `TestConvex<typeof schema>` accepted by existing component `register(t)` helpers, including custom registration names. Named fixtures use the existing runtime for validation, nested calls, scheduling, callback handles, and rollback. The utility stays in `index.ts` alongside the shared runtime constructor.

Add usage documentation and 12 regression tests covering runtime behavior and type safety. Include the test TypeScript project in the build so invalid arguments, references, and schema access are checked in CI.

Validation: `npm run clean && npm run build` passed lint, type checks, and all 269 tests.
