### PR TITLE
Avoid consuming mocked randomness for request IDs

### DIFF
--- a/convex/globals.test.ts
+++ b/convex/globals.test.ts
@@ -39,6 +39,31 @@ test("nested mutations do not consume the caller's random sequence", async () =>
   expect(await sample(false)).toEqual([0.1, 0.2]);
 });
 
+test.each(["action", "inline action", "run"])(
+  "nested %s does not consume the caller's random sequence",
+  async (method) => {
+    const t = convexTest(schema);
+    const result = await t.action(async (ctx) => {
+      const patchedMath: Math = Object.create(Math);
+      let draws = 0;
+      patchedMath.random = () => ++draws / 10;
+      globalThis.Math = patchedMath;
+
+      const before = Math.random();
+      if (method === "action") {
+        await ctx.runAction(internal.globals.readAtobAction);
+      } else if (method === "inline action") {
+        await t.action(async () => null);
+      } else {
+        await t.run(async () => null);
+      }
+      return [before, Math.random()];
+    });
+
+    expect(result).toEqual([0.1, 0.2]);
+  },
+);
+
 test.each(["process", "Crypto", "crypto", "CryptoKey", "SubtleCrypto"])(
   "assigning undefined to %s is isolated from nested calls and the test",
   async (name) => {

--- a/index.ts
+++ b/index.ts
@@ -2698,7 +2698,7 @@ function yieldThroughRealTimers(): Promise<void> {
 }
 
 // Request IDs are internal bookkeeping. Generating them must not consume a
-// handler's mocked Math.random sequence.
+// handler's mocked Math.random sequence. The prefix marks these as test-only IDs.
 let nextRequestId = 0;
 
 function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
@@ -2861,7 +2861,7 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
       paginatedQueries: 0,
     };
     return await executionContextStorage.run(childCtx, async () => {
-      const requestId = String(nextRequestId++);
+      const requestId = `fake-request-id-${nextRequestId++}`;
       try {
         const rawResult = await authStorage.run(authForChild, () =>
           (
@@ -3137,8 +3137,7 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
         );
       },
     });
-    // Real backend uses different ID format
-    const requestId = String(nextRequestId++);
+    const requestId = `fake-request-id-${nextRequestId++}`;
     try {
       const rawResult = await (
         a as unknown as {

--- a/index.ts
+++ b/index.ts
@@ -2697,6 +2697,10 @@ function yieldThroughRealTimers(): Promise<void> {
   return new Promise<void>((r) => realSetTimeout(r, 0));
 }
 
+// Request IDs are internal bookkeeping. Generating them must not consume a
+// handler's mocked Math.random sequence.
+let nextRequestId = 0;
+
 function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
   // Auth doesn't propagate across component boundaries.
   function authForComponent(componentPath: string) {
@@ -2857,7 +2861,7 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
       paginatedQueries: 0,
     };
     return await executionContextStorage.run(childCtx, async () => {
-      const requestId = "" + Math.random();
+      const requestId = String(nextRequestId++);
       try {
         const rawResult = await authStorage.run(authForChild, () =>
           (
@@ -3134,7 +3138,7 @@ function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
       },
     });
     // Real backend uses different ID format
-    const requestId = "" + Math.random();
+    const requestId = String(nextRequestId++);
     try {
       const rawResult = await (
         a as unknown as {


### PR DESCRIPTION
We can be more careful by avoiding calling globals that may rely on seeds (in the case of Workflow)

Nested action calls and `t.run` consumed an extra value from the caller's mocked `Math.random` sequence while generating internal request IDs. Use a private counter so a caller that draws `0.1`, invokes a child, then draws again gets `0.2`. Prefix IDs with `fake-request-id-` to make clear they do not represent production request IDs.

Stacked directly on #83, independently of #142. Regression tests cover registered actions, inline actions, and `t.run`.

Validation: all 302 tests pass; `npm run build` (including lint) and `tsc --noEmit -p convex/tsconfig.json` pass. The three new tests fail before the fix.
