### PR TITLE
fix: lint against reading proxied globals in framework code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- `ctx.storage.generateUploadUrl()` no longer consumes randomness from a handler
+  that mocked `Math.random`, and returns a unique URL even when it did.
+
 ## 0.0.58
 
 - Globals modified within query/mutation/actions (e.g. for Workflow) are now

--- a/convex/storage.test.ts
+++ b/convex/storage.test.ts
@@ -71,3 +71,29 @@ test("mutation generate upload URL", async () => {
   const result = await t.mutation(internal.storage.mutationGenerateUploadUrl);
   expect(result).toMatch("https://");
 });
+
+test("storing a blob doesn't go through patchable globals", async () => {
+  const t = convexTest(schema);
+  const bytes = new Uint8Array([0b00001100, 0b00000000]).buffer;
+  const storageId = await t.action(
+    internal.storage.actionStoreBlobWithPatchedGlobals,
+    { bytes },
+  );
+  const result = await t.query(internal.storage.listFiles);
+  expect(result).toMatchObject([
+    {
+      _id: storageId,
+      sha256: "v2DkNJys5rzg1VLo14NCjbZtDWSb2eQwo2J+LuFKyDk=",
+      size: 2,
+    },
+  ]);
+});
+
+test("upload URLs don't consume a handler's mocked randomness", async () => {
+  const t = convexTest(schema);
+  const [first, second] = await t.mutation(
+    internal.storage.mutationGenerateUploadUrlsWithPatchedRandom,
+  );
+  expect(first).not.toEqual(second);
+  expect(first).not.toMatch("0.5");
+});

--- a/convex/storage.ts
+++ b/convex/storage.ts
@@ -77,3 +77,32 @@ export const mutationGenerateUploadUrl = internalMutation({
     return await ctx.storage.generateUploadUrl();
   },
 });
+
+/// globals that the framework uses internally
+
+// `convexTest` hashes stored blobs with `crypto` and `btoa`, and builds upload
+// tokens without randomness. Patching those globals here checks that storage
+// neither breaks nor observes the patches.
+export const actionStoreBlobWithPatchedGlobals = internalAction({
+  args: {
+    bytes: v.bytes(),
+  },
+  handler: async (ctx, { bytes }) => {
+    (globalThis as any).crypto = {};
+    (globalThis as any).btoa = () => "patched";
+    return await ctx.storage.store(new Blob([bytes]));
+  },
+});
+
+export const mutationGenerateUploadUrlsWithPatchedRandom = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const patchedMath = Object.create(Math) as Math;
+    patchedMath.random = () => 0.5;
+    (globalThis as any).Math = patchedMath;
+    return [
+      await ctx.storage.generateUploadUrl(),
+      await ctx.storage.generateUploadUrl(),
+    ];
+  },
+});

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -61,6 +61,56 @@ export default defineConfig([
       "@typescript-eslint/require-await": "off",
     },
   },
+  {
+    // `installGlobalProxies` (see `PATCHABLE_GLOBALS` in `index.ts`) replaces
+    // these globals with accessors backed by AsyncLocalStorage, so reading one
+    // by its bare name can return a value that a test or a handler installed.
+    // Capture the global at module load instead (`realSetTimeout`, `realBtoa`,
+    // …). Where the framework genuinely has to read the live value — the clock,
+    // which fake timers replace after this module loads — give it one named
+    // accessor (`nowMs`, `frameworkSetTimeout`) so `globalThis` appears at the
+    // declaration and the call sites stay readable.
+    files: ["index.ts", "transactionMetrics.ts"],
+    rules: {
+      "no-restricted-globals": [
+        "error",
+        ...[
+          "crypto",
+          "atob",
+          "btoa",
+          "structuredClone",
+          "fetch",
+          "setTimeout",
+          "clearTimeout",
+          "setInterval",
+          "clearInterval",
+          "Date",
+          "console",
+        ].map((name) => ({
+          name,
+          message:
+            `\`${name}\` is proxied per handler. Capture it at module load, or ` +
+            `read it through a named accessor that documents why it has to be live.`,
+        })),
+      ],
+
+      // `Math` as a whole isn't restricted: `Math.floor` and friends are only
+      // at risk from a handler that replaces the whole object, and prefixing
+      // every one of them costs more than it saves. `Math.random` is different:
+      // it consumes a handler's mocked sequence, so the framework must never
+      // call it.
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            "MemberExpression[object.name='Math'][property.name='random']",
+          message:
+            "`Math.random` consumes a handler's mocked randomness. Use a " +
+            "counter for fake identifiers, or capture randomness at module load.",
+        },
+      ],
+    },
+  },
   globalIgnores([
     ".context/**",
     "**/.eslintrc.cjs",

--- a/index.ts
+++ b/index.ts
@@ -252,7 +252,7 @@ class DatabaseFake {
   insert<Table extends TableName>(table: Table, value: any) {
     this._validate(table, value);
     const _id = this._generateId(table);
-    const now = Date.now();
+    const now = nowMs();
     const _creationTime =
       now <= this._lastCreationTime ? this._lastCreationTime + 0.001 : now;
     this._lastCreationTime = _creationTime;
@@ -1726,7 +1726,7 @@ function asyncSyscallImpl() {
                     try {
                       await withAuth().fun(functionPath, parsedArgs);
                     } catch (error) {
-                      console.error(
+                      realConsole.error(
                         `Error when running scheduled function ${name}`,
                         error,
                       );
@@ -1735,7 +1735,7 @@ function asyncSyscallImpl() {
                         async () => {
                           db.patch("_scheduled_functions", jobId, {
                             state: { kind: "failed" },
-                            completedTime: Date.now(),
+                            completedTime: nowMs(),
                           });
                         },
                       );
@@ -1762,7 +1762,7 @@ function asyncSyscallImpl() {
                 });
               scheduler.add(promise);
             },
-            Math.max(0, tsInSecs * 1000 - Date.now()),
+            Math.max(0, tsInSecs * 1000 - nowMs()),
           );
         });
         return JSON.stringify(convexToJson(jobId));
@@ -1816,7 +1816,7 @@ function asyncSyscallImpl() {
         // In the real backend the token is cryptographically secure
         const url =
           "https://some-deployment.convex.cloud/api/storage/upload?token=" +
-          Math.random();
+          `fake-upload-token-${nextUploadToken++}`;
         return JSON.stringify(convexToJson(url));
       }
       case "1.0/count": {
@@ -1888,9 +1888,9 @@ async function writeToDatabase<T>(impl: (db: DatabaseFake) => Promise<T>) {
 
 async function blobSha(blob: Blob) {
   const arrayBuffer = await blob.arrayBuffer();
-  const hashBuffer = await crypto.subtle.digest("SHA-256", arrayBuffer);
+  const hashBuffer = await realCryptoSubtle.digest("SHA-256", arrayBuffer);
   const hashArray = new Uint8Array(hashBuffer);
-  return btoa(String.fromCharCode(...hashArray));
+  return realBtoa(String.fromCharCode(...hashArray));
 }
 
 export type TestConvex<SchemaDef extends SchemaDefinition<any, boolean>> =
@@ -2472,7 +2472,7 @@ class TransactionManager {
   commit(isNested: boolean): bigint | null {
     let commitTs: bigint | null = null;
     if (!isNested) {
-      const nowNanos = BigInt(Date.now()) * 1_000_000n;
+      const nowNanos = BigInt(nowMs()) * 1_000_000n;
       // Assign a new timestamp only when committing the outermost transaction.
       // Bump by one if the clock is frozen or has moved backwards.
       commitTs =
@@ -2692,6 +2692,20 @@ function yieldToEventLoop(): Promise<void> {
 // expired real timers fire. Awaiting a real 0ms timeout does: all timers
 // that expired earlier fire first.
 const realSetTimeout = globalThis.setTimeout.bind(globalThis);
+const realCryptoSubtle = globalThis.crypto.subtle;
+const realBtoa = globalThis.btoa.bind(globalThis);
+// Captured, not read at call time, so a handler that replaces `globalThis.console`
+// can't swallow the framework's own output. `vi.spyOn(console, "error")` patches
+// the method on this same object, so tests can still observe it.
+const realConsole = globalThis.console;
+
+// Unlike the captures above, the clock has to be read at call time: fake timers
+// replace `globalThis.Date` outright after this module loads, and the fake
+// backend's timestamps have to follow the clock the test set up. Capturing
+// `Date.now` here instead fails the `getSnapshotTs` and `by_creation_time` tests.
+function nowMs() {
+  return globalThis.Date.now();
+}
 
 function yieldThroughRealTimers(): Promise<void> {
   return new Promise<void>((r) => realSetTimeout(r, 0));
@@ -2700,6 +2714,9 @@ function yieldThroughRealTimers(): Promise<void> {
 // Request IDs are internal bookkeeping. Generating them must not consume a
 // handler's mocked Math.random sequence. The prefix marks these as test-only IDs.
 let nextRequestId = 0;
+
+// Upload tokens only have to be unique. The prefix marks them as test-only.
+let nextUploadToken = 0;
 
 function withAuth(auth: AuthFake = authStorage.getStore() ?? new AuthFake()) {
   // Auth doesn't propagate across component boundaries.


### PR DESCRIPTION
`installGlobalProxies` turns the globals in `PATCHABLE_GLOBALS` into
accessors backed by AsyncLocalStorage, so a bare read inside `convexTest`
can return whatever a test or a handler installed. Nothing enforced that,
and `storageGenerateUploadUrl` was already affected: it built its token
with `Math.random()`, consuming a handler's mocked sequence and returning
the same URL twice when the mock was constant.

Restrict those names with `no-restricted-globals` on the framework
sources, plus a `no-restricted-syntax` selector for `Math.random` (the
rest of `Math` isn't worth prefixing everywhere). The escape hatch is
`globalThis.<name>`, which the rule allows and which reads as "the live,
possibly overridden value on purpose" — used for `Date.now` so fake
timers keep working, and for `console.error` so tests can spy on it.

Upload tokens now come from a counter like request IDs, and `blobSha`
hashes through references captured at module load.